### PR TITLE
Encapsulate config write

### DIFF
--- a/production/production_config.py
+++ b/production/production_config.py
@@ -159,6 +159,12 @@ features:
   structured_logging: true
 """
 
-# Save the production config template
-with open('production_config.yaml', 'w') as f:
-    f.write(PRODUCTION_CONFIG_YAML)
+def save_default_config(path: str = "production_config.yaml") -> None:
+    """Write the default production configuration to ``path``.
+
+    Files are only created when this function is explicitly called.
+    """
+
+    with open(path, "w") as f:
+        f.write(PRODUCTION_CONFIG_YAML)
+


### PR DESCRIPTION
## Summary
- add `save_default_config()` to wrap writing of `production_config.yaml`
- remove side effect so importing `production_config` no longer writes files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685449bc0048832e871d2f6b06d02061