### PR TITLE
Add typing imports to health integration

### DIFF
--- a/production/health_integration.py
+++ b/production/health_integration.py
@@ -7,6 +7,7 @@ from monitoring import health_monitor
 from production_logging import get_logger
 import time
 import asyncio
+from typing import Dict, Any
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure `Dict` and `Any` are available in `health_integration`

## Testing
- `python -m py_compile production/health_integration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685449b48e08832ea7465bfc653adc4e