### PR TITLE
Fix bootstrap launch prints

### DIFF
--- a/ncos_launcher.py
+++ b/ncos_launcher.py
@@ -88,11 +88,9 @@ def main():
         print("⚠️  Warning: bootstrap.yaml not found, will use defaults")
 
     # Launch the bootstrap
-    print("
-" + "=" * 40)
+    print("\n" + "=" * 40)
     print("Launching NCOS Bootstrap...")
-    print("=" * 40 + "
-")
+    print("=" * 40 + "\n")
 
     # Run the bootstrap script
     try:


### PR DESCRIPTION
## Summary
- restore the bootstrap launch banner in `ncos_launcher.py`

## Testing
- `python3 -m py_compile ncos_launcher.py`


------
https://chatgpt.com/codex/tasks/task_b_685449adc4d4832eb262e020def2744b