### PR TITLE
Fix risk format in agent registry

### DIFF
--- a/agent_registry_strategy_update.yaml
+++ b/agent_registry_strategy_update.yaml
@@ -9,7 +9,7 @@ strategy_agents:
     max_positions: 1
     module: ncos.agents.strategies.micro_wyckoff_event
     priority: 10
-    risk_per_trade: 1%
+    risk_per_trade: 0.01
     risk_profile: precision
     timeframes:
     - tick
@@ -28,7 +28,7 @@ strategy_agents:
     max_positions: 1
     module: ncos.agents.strategies.orderflow_anomaly
     priority: 11
-    risk_per_trade: 1.5%
+    risk_per_trade: 0.015
     risk_profile: defensive
     timeframes:
     - M1
@@ -47,7 +47,7 @@ strategy_agents:
     max_positions: 3
     module: ncos.agents.strategies.protection_reentry
     priority: 12
-    risk_per_trade: 1%
+    risk_per_trade: 0.01
     risk_profile: protective
     timeframes:
     - M1
@@ -66,7 +66,7 @@ strategy_agents:
     max_positions: 2
     module: ncos.agents.strategies.session_sweep_reversal
     priority: 9
-    risk_per_trade: 2%
+    risk_per_trade: 0.02
     risk_profile: moderate
     timeframes:
     - M5
@@ -86,7 +86,7 @@ strategy_agents:
     max_positions: 2
     module: ncos.agents.strategies.smc_liquidity_trap
     priority: 7
-    risk_per_trade: 2.5%
+    risk_per_trade: 0.025
     risk_profile: aggressive
     timeframes:
     - M1
@@ -105,7 +105,7 @@ strategy_agents:
     max_positions: 1
     module: ncos.agents.strategies.wyckoff_phase_cycle
     priority: 8
-    risk_per_trade: 1.5%
+    risk_per_trade: 0.015
     risk_profile: conservative
     timeframes:
     - H1

--- a/config/agent_registry.yaml
+++ b/config/agent_registry.yaml
@@ -75,7 +75,7 @@ strategy_agents:
     max_positions: 1
     module: ncos.agents.strategies.micro_wyckoff_event
     priority: 10
-    risk_per_trade: 1%
+    risk_per_trade: 0.01
     risk_profile: precision
     timeframes:
     - tick
@@ -94,7 +94,7 @@ strategy_agents:
     max_positions: 1
     module: ncos.agents.strategies.orderflow_anomaly
     priority: 11
-    risk_per_trade: 1.5%
+    risk_per_trade: 0.015
     risk_profile: defensive
     timeframes:
     - M1
@@ -113,7 +113,7 @@ strategy_agents:
     max_positions: 3
     module: ncos.agents.strategies.protection_reentry
     priority: 12
-    risk_per_trade: 1%
+    risk_per_trade: 0.01
     risk_profile: protective
     timeframes:
     - M1
@@ -132,7 +132,7 @@ strategy_agents:
     max_positions: 2
     module: ncos.agents.strategies.session_sweep_reversal
     priority: 9
-    risk_per_trade: 2%
+    risk_per_trade: 0.02
     risk_profile: moderate
     timeframes:
     - M5
@@ -152,7 +152,7 @@ strategy_agents:
     max_positions: 2
     module: ncos.agents.strategies.smc_liquidity_trap
     priority: 7
-    risk_per_trade: 2.5%
+    risk_per_trade: 0.025
     risk_profile: aggressive
     timeframes:
     - M1
@@ -171,7 +171,7 @@ strategy_agents:
     max_positions: 1
     module: ncos.agents.strategies.wyckoff_phase_cycle
     priority: 8
-    risk_per_trade: 1.5%
+    risk_per_trade: 0.015
     risk_profile: conservative
     timeframes:
     - H1


### PR DESCRIPTION
## Summary
- convert `risk_per_trade` from percent strings to decimals
- fix YAML indentation in update registry

## Testing
- `python -m unittest tests.test_ncos_agents`
- `python tests/integration_tests.py`
- `python scripts/stress_test_framework.py` *(fails: ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_b_6854647480b4832ebd71d552cdaa1670