### PR TITLE
Add new strategy agents to init order

### DIFF
--- a/config/bootstrap.yaml
+++ b/config/bootstrap.yaml
@@ -19,6 +19,12 @@ agents:
     - "BroadcastRelay"
     - "ReportGenerator"
     - "SessionStateManager"
+    - "smc_liquidity_trap"
+    - "wyckoff_phase_cycle"
+    - "session_sweep_reversal"
+    - "micro_wyckoff_event"
+    - "orderflow_anomaly"
+    - "protection_reentry"
 
   configurations:
     CoreSystemAgent:


### PR DESCRIPTION
## Summary
- append strategy agent names to `agents.initialization_order`
- order the strategy agents according to priority values in `agent_registry.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68546473913c832e83cb94c0f55f92ca