### PR TITLE
Fix config path references

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -19,7 +19,7 @@
    ```
 
 3. **Configure System**
-   Edit configs/bootstrap.yaml as needed
+   Edit config/bootstrap.yaml as needed
 
 4. **Start System**
    ```bash

--- a/ncos_strategy_integration_complete.json
+++ b/ncos_strategy_integration_complete.json
@@ -134,9 +134,9 @@
     "step_2_config_integration": {
       "description": "Integrate strategy configs into NCOS system",
       "files_to_update": [
-        "configs/agent_registry.yaml",
-        "configs/strategy_profiles.json",
-        "configs/trigger_routes.toml"
+        "config/agent_registry.yaml",
+        "config/strategy_profiles.json",
+        "config/trigger_routes.toml"
       ]
     },
     "step_3_orchestrator_integration": {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -130,7 +130,7 @@ setup_configurations() {
     echo -e "${YELLOW}Setting up configurations...${NC}"
 
     # Copy configuration files
-    cp "$DEPLOYMENT_DIR"/configs/*.yaml "$CONFIG_DIR/" 2>/dev/null || true
+    cp "$DEPLOYMENT_DIR"/config/*.yaml "$CONFIG_DIR/" 2>/dev/null || true
 
     # Create default bootstrap.yaml if not exists
     if [ ! -f "$CONFIG_DIR/bootstrap.yaml" ]; then


### PR DESCRIPTION
## Summary
- correct config path references in integration JSON
- fix documentation for bootstrap config
- align deploy script with config directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685465bcc34c832e98d3f6d5b72e1160