### PR TITLE
Fix NameError in integration bootstrap scripts

### DIFF
--- a/scripts/integration_bootstrap.py
+++ b/scripts/integration_bootstrap.py
@@ -12,6 +12,7 @@ import logging
 from typing import Dict, List, Any, Optional
 from datetime import datetime
 from pathlib import Path
+import importlib
 import importlib.util
 import traceback
 

--- a/scripts/integration_bootstrap_old.py
+++ b/scripts/integration_bootstrap_old.py
@@ -12,6 +12,7 @@ import logging
 from typing import Dict, List, Any, Optional
 from datetime import datetime
 from pathlib import Path
+import importlib
 import importlib.util
 import traceback
 


### PR DESCRIPTION
## Summary
- add `import importlib` to integration bootstrap scripts

## Testing
- `python scripts/integration_bootstrap.py` *(fails: No module named 'yaml')*
- `python scripts/integration_bootstrap_old.py` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_685472b21d98832eb5038e0abd6e95d7