### PR TITLE
Add stub trading engine modules

### DIFF
--- a/enhanced_vector_engine.py
+++ b/enhanced_vector_engine.py
@@ -1,0 +1,34 @@
+"""Stub vector engine and Brown vector store integration for ncOScore."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class ncOScoreVectorEngine:
+    """Simple placeholder vector engine."""
+
+    def __init__(self, dimensions: int, memory_manager: Any | None = None) -> None:
+        self.dimensions = dimensions
+        self.memory_manager = memory_manager
+        self.vectors: Dict[str, List[float]] = {}
+
+    async def embed_market_data(self, df: Any, key: str) -> Dict[str, Any]:  # pragma: no cover - stub
+        self.vectors[key] = [0.0] * self.dimensions
+        return {"vector_id": key, "status": "success"}
+
+    async def pattern_matching(self, df: Any, pattern: str) -> Dict[str, Any]:  # pragma: no cover - stub
+        return {"status": "success", "similar_patterns": []}
+
+    def get_vector_store_stats(self) -> Dict[str, Any]:  # pragma: no cover - stub
+        return {"total_vectors": len(self.vectors)}
+
+
+class BrownVectorStoreIntegration:
+    """Placeholder for an advanced vector store."""
+
+    def __init__(self, engine: ncOScoreVectorEngine) -> None:
+        self.engine = engine
+
+    def info(self) -> Dict[str, Any]:  # pragma: no cover - stub
+        return {"connected": True, "vectors": self.engine.get_vector_store_stats()}

--- a/liquidity_analysis_engine.py
+++ b/liquidity_analysis_engine.py
@@ -1,0 +1,16 @@
+"""Stub liquidity analysis engine for ncOScore."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class ncOScoreLiquidityEngine:
+    """Placeholder liquidity analysis engine."""
+
+    def __init__(self, session_state: Any, config: Dict[str, Any] | None = None) -> None:
+        self.session_state = session_state
+        self.config = config or {}
+
+    async def analyze_liquidity(self, df: Any) -> Dict[str, Any]:  # pragma: no cover - stub
+        return {"sweep_probability": 0.0, "high_probability_zones": [], "status": "success"}

--- a/smc_analysis_engine.py
+++ b/smc_analysis_engine.py
@@ -1,0 +1,17 @@
+"""Stub Smart Money Concepts analysis engine for ncOScore."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class ncOScoreSMCEngine:
+    """Placeholder SMC engine used in testing and development."""
+
+    def __init__(self, session_state: Any, config: Dict[str, Any] | None = None) -> None:
+        self.session_state = session_state
+        self.config = config or {}
+
+    async def analyze_market_structure(self, df: Any) -> Dict[str, Any]:  # pragma: no cover - stub
+        """Return a minimal market structure analysis."""
+        return {"confluence_score": 0.0, "signals": [], "status": "success"}


### PR DESCRIPTION
## Summary
- add placeholder `ncOScoreSMCEngine`
- add simple vector engine with Brown store integration
- provide liquidity analysis engine stub

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685488ef8684832e8d63058010b97c67