### PR TITLE
Fix README deploy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This package contains all components needed to run NCOS v21.
 - `agents/` - All 13 agent implementations
 - `config/` - Bootstrap and registry configurations  
 - `scripts/` - Integration bootstrap script
-- `deploy.sh` - Quick deployment script
+- `scripts/deploy.sh` - Quick deployment script
 
 ## Agents Included
 


### PR DESCRIPTION
## Summary
- fix quick-start reference to `scripts/deploy.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68548cc060c4832eb954ad2f9f7942fd