### PR TITLE
Fix path for orchestrator imports in test suite

### DIFF
--- a/ncos_v21_7_1_integration_test_suite.py
+++ b/ncos_v21_7_1_integration_test_suite.py
@@ -11,6 +11,12 @@ from datetime import datetime
 import json
 import traceback
 from pathlib import Path
+import sys
+
+# Ensure the project root is available on the import path so this
+# standalone test suite can import project modules when executed from
+# any location.
+sys.path.append(str(Path(__file__).resolve().parent))
 
 class NCOSIntegrationTestSuite:
     """Comprehensive integration testing suite"""

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -11,6 +11,12 @@ from datetime import datetime
 from typing import Dict, List, Any, Optional
 import threading
 import queue
+import sys
+from pathlib import Path
+
+# Ensure project root is on the import path so integration
+# tests can import modules that live alongside this directory.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 # Mock implementations for integration testing
 class MockMarketDataProvider:


### PR DESCRIPTION
## Summary
- update `tests/integration_tests.py` to add project root to `sys.path`
- update integration suite to include root path for imports

## Testing
- `pytest -q`
- `python ncos_v21_7_1_integration_test_suite.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68548d07f418832e8d0f28664f5fe5e3