### PR TITLE
Update Python requirement to 3.10

### DIFF
--- a/PACKAGE_INFO.json
+++ b/PACKAGE_INFO.json
@@ -8,7 +8,7 @@
     "scripts": 3
   },
   "requirements": {
-    "python": ">=3.8",
+    "python": ">=3.10",
     "memory": "4GB",
     "disk": "10GB"
   }

--- a/README_NCOS_v21_7_1_Enhanced_Complete.md
+++ b/README_NCOS_v21_7_1_Enhanced_Complete.md
@@ -25,7 +25,7 @@ python ncos_v21_7_1_integration_test_suite.py
 ```
 
 ### System Requirements
-- Python 3.8+
+ - Python 3.10+
 - pandas, numpy, scikit-learn
 - 8GB RAM minimum (16GB recommended)
 - 2GB storage for vector operations

--- a/README_v21.7.1.md
+++ b/README_v21.7.1.md
@@ -52,7 +52,7 @@ Knowledge Base → Intelligence → Workflow → Triggers → State Manager
 ## 🚀 **Quick Start**
 
 ### **Prerequisites**
-- Python 3.9+
+ - Python 3.10+
 - Redis (for L1 memory)
 - PostgreSQL with pgvector (for L3 memory)
 - FAISS (for L2 vector similarity)

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,7 +1,7 @@
 # NCOS v21 Deployment Guide
 
 ## Prerequisites
-- Python 3.8+
+ - Python 3.10+
 - 4GB RAM minimum (8GB recommended)
 - 10GB disk space
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ncOS"
 version = "0.1.0"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [project.scripts]
 ncos = "ncOS.ncos_launcher:main"

--- a/requirements_v21.7.1.txt
+++ b/requirements_v21.7.1.txt
@@ -2,7 +2,7 @@
 # Neural Cognitive Operating System Dependencies
 
 # Core Dependencies
-python>=3.9.0
+python>=3.10.0
 pydantic>=2.0.0
 pyyaml>=6.0
 aiohttp>=3.8.0

--- a/setup_v21.7.1.py
+++ b/setup_v21.7.1.py
@@ -42,13 +42,12 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=requirements,
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary
- require Python 3.10 in `pyproject.toml`
- document Python 3.10+ requirement in deployment and README docs
- update packaging metadata and example requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68549161f524832eba97da9ccd66f0d0