### PR TITLE
Add NCOSBaseAgent and async agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This package contains all components needed to run NCOS v21.
 11. SMCRouter - Smart routing
 12. MAZ2Executor - MAZ2 execution
 13. TMCExecutor - TMC execution
+14. LiquiditySniperAgent - Liquidity sweep detection
+15. EntryExecutorSMCAgent - Executes precision entries
 
 ## Notes
 

--- a/agents/entry_executor_smc.py
+++ b/agents/entry_executor_smc.py
@@ -1,0 +1,20 @@
+"""Execution agent for SMC precision entries."""
+from typing import Any, Dict
+
+from .ncos_base_agent import NCOSBaseAgent
+
+
+class EntryExecutorSMCAgent(NCOSBaseAgent):
+    """Submit entries when signalled by strategies."""
+
+    def __init__(self, orchestrator: Any, config: Dict[str, Any] | None = None) -> None:
+        super().__init__(orchestrator, config)
+        self.agent_id = "entry_executor_smc"
+        self.register_trigger("precision_entry", self._execute_entry)
+
+    async def _execute_entry(self, payload: Dict[str, Any], session_state: Dict[str, Any]) -> None:
+        await self.orchestrator.route_trigger(
+            "execution.entry.submitted",
+            payload,
+            session_state,
+        )

--- a/agents/liquidity_sniper.py
+++ b/agents/liquidity_sniper.py
@@ -1,0 +1,20 @@
+"""Simple liquidity sniper agent."""
+from typing import Any, Dict
+
+from .ncos_base_agent import NCOSBaseAgent
+
+
+class LiquiditySniperAgent(NCOSBaseAgent):
+    """Detect liquidity pools and forward events."""
+
+    def __init__(self, orchestrator: Any, config: Dict[str, Any] | None = None) -> None:
+        super().__init__(orchestrator, config)
+        self.agent_id = "liquidity_sniper"
+        self.register_trigger("liquidity_pool_identified", self._on_pool)
+
+    async def _on_pool(self, payload: Dict[str, Any], session_state: Dict[str, Any]) -> None:
+        await self.orchestrator.route_trigger(
+            "liquidity_sniper.pool_identified",
+            payload,
+            session_state,
+        )

--- a/agents/ncos_base_agent.py
+++ b/agents/ncos_base_agent.py
@@ -1,0 +1,26 @@
+"""NCOS base agent with async trigger support."""
+import logging
+from typing import Any, Awaitable, Callable, Dict
+
+
+class NCOSBaseAgent:
+    """Minimal asynchronous agent base class."""
+
+    def __init__(self, orchestrator: Any, config: Dict[str, Any] | None = None) -> None:
+        self.orchestrator = orchestrator
+        self.config = config or {}
+        self.agent_id = self.config.get("agent_id", self.__class__.__name__.lower())
+        self.logger = logging.getLogger(self.agent_id)
+        self.trigger_handlers: Dict[str, Callable[[Dict[str, Any], Dict[str, Any]], Awaitable[None]]] = {}
+
+    async def handle_trigger(self, trigger_name: str, payload: Dict[str, Any], session_state: Dict[str, Any]) -> None:
+        """Dispatch trigger to registered handler if available."""
+        handler = self.trigger_handlers.get(trigger_name)
+        if handler:
+            await handler(payload, session_state)
+        else:
+            self.logger.debug("No handler for trigger %s", trigger_name)
+
+    def register_trigger(self, trigger_name: str, handler: Callable[[Dict[str, Any], Dict[str, Any]], Awaitable[None]]) -> None:
+        """Register a handler for a trigger name."""
+        self.trigger_handlers[trigger_name] = handler

--- a/config/agent_registry.yaml
+++ b/config/agent_registry.yaml
@@ -79,6 +79,14 @@ agents:
     module: "ncos_compliance_agent"
     class: "ComplianceAgent"
     enabled: true
+  liquidity_sniper:
+    module: "liquidity_sniper"
+    class: "LiquiditySniperAgent"
+    enabled: true
+  entry_executor_smc:
+    module: "entry_executor_smc"
+    class: "EntryExecutorSMCAgent"
+    enabled: true
 strategy_agents:
   micro_wyckoff_event:
     class: MicroWyckoffEventAgent

--- a/tests/test_async_agents.py
+++ b/tests/test_async_agents.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from agents.liquidity_sniper import LiquiditySniperAgent
+from agents.entry_executor_smc import EntryExecutorSMCAgent
+
+
+class DummyOrchestrator:
+    def __init__(self):
+        self.calls = []
+
+    async def route_trigger(self, name, payload, state):
+        self.calls.append((name, payload, state))
+
+
+def test_liquidity_sniper_trigger():
+    orch = DummyOrchestrator()
+    agent = LiquiditySniperAgent(orch, {})
+    asyncio.run(agent.handle_trigger("liquidity_pool_identified", {"level": 1}, {}))
+    assert orch.calls == [("liquidity_sniper.pool_identified", {"level": 1}, {})]
+
+
+def test_entry_executor_trigger():
+    orch = DummyOrchestrator()
+    agent = EntryExecutorSMCAgent(orch, {})
+    asyncio.run(agent.handle_trigger("precision_entry", {"symbol": "TEST"}, {}))
+    assert orch.calls == [("execution.entry.submitted", {"symbol": "TEST"}, {})]


### PR DESCRIPTION
## Summary
- add NCOSBaseAgent class for async trigger handling
- implement LiquiditySniperAgent and EntryExecutorSMCAgent
- register new agents in agent registry
- document new agents in README
- add unit tests covering new async agents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68549209ffac832eaf3e55e32678a095