### PR TITLE
Fix strategy config paths

### DIFF
--- a/README_v21.7.1.md
+++ b/README_v21.7.1.md
@@ -148,7 +148,7 @@ enhanced_ncos_agents:
 
 ### **Strategy Configuration**
 ```yaml
-# configs/strategies/smc_liquidity_trap.yaml
+# config/strategies/smc_liquidity_trap.yaml
 strategy:
   name: "SMC Liquidity Trap"
   risk_per_trade: "2.5%"

--- a/agent_registry_strategy_update.yaml
+++ b/agent_registry_strategy_update.yaml
@@ -1,7 +1,7 @@
 strategy_agents:
   micro_wyckoff_event:
     class: MicroWyckoffEventAgent
-    config_file: configs/strategies/micro_wyckoff_event.yaml
+    config_file: config/strategies/micro_wyckoff_event.yaml
     dependencies:
     - master_orchestrator
     - risk_guardian
@@ -20,7 +20,7 @@ strategy_agents:
     type: tick_analysis
   orderflow_anomaly:
     class: OrderflowAnomalyAgent
-    config_file: configs/strategies/orderflow_anomaly.yaml
+    config_file: config/strategies/orderflow_anomaly.yaml
     dependencies:
     - master_orchestrator
     - liquidity_sniper
@@ -39,7 +39,7 @@ strategy_agents:
     type: orderflow_analysis
   protection_reentry:
     class: ProtectionReentryAgent
-    config_file: configs/strategies/protection_reentry.yaml
+    config_file: config/strategies/protection_reentry.yaml
     dependencies:
     - risk_guardian
     - session_state_manager
@@ -58,7 +58,7 @@ strategy_agents:
     type: risk_management
   session_sweep_reversal:
     class: SessionSweepReversalAgent
-    config_file: configs/strategies/session_sweep_reversal.yaml
+    config_file: config/strategies/session_sweep_reversal.yaml
     dependencies:
     - master_orchestrator
     - entry_executor_smc
@@ -77,7 +77,7 @@ strategy_agents:
     type: session_trading
   smc_liquidity_trap:
     class: SMCLiquidityTrapAgent
-    config_file: configs/strategies/smc_liquidity_trap.yaml
+    config_file: config/strategies/smc_liquidity_trap.yaml
     dependencies:
     - master_orchestrator
     - liquidity_sniper
@@ -97,7 +97,7 @@ strategy_agents:
     type: smc_execution
   wyckoff_phase_cycle:
     class: WyckoffPhaseCycleAgent
-    config_file: configs/strategies/wyckoff_phase_cycle.yaml
+    config_file: config/strategies/wyckoff_phase_cycle.yaml
     dependencies:
     - master_orchestrator
     - session_state_manager

--- a/config/agent_registry.yaml
+++ b/config/agent_registry.yaml
@@ -90,7 +90,7 @@ agents:
 strategy_agents:
   micro_wyckoff_event:
     class: MicroWyckoffEventAgent
-    config_file: configs/strategies/micro_wyckoff_event.yaml
+    config_file: config/strategies/micro_wyckoff_event.yaml
     dependencies:
     - master_orchestrator
     - risk_guardian
@@ -109,7 +109,7 @@ strategy_agents:
     type: tick_analysis
   orderflow_anomaly:
     class: OrderflowAnomalyAgent
-    config_file: configs/strategies/orderflow_anomaly.yaml
+    config_file: config/strategies/orderflow_anomaly.yaml
     dependencies:
     - master_orchestrator
     - liquidity_sniper
@@ -128,7 +128,7 @@ strategy_agents:
     type: orderflow_analysis
   protection_reentry:
     class: ProtectionReentryAgent
-    config_file: configs/strategies/protection_reentry.yaml
+    config_file: config/strategies/protection_reentry.yaml
     dependencies:
     - risk_guardian
     - session_state_manager
@@ -147,7 +147,7 @@ strategy_agents:
     type: risk_management
   session_sweep_reversal:
     class: SessionSweepReversalAgent
-    config_file: configs/strategies/session_sweep_reversal.yaml
+    config_file: config/strategies/session_sweep_reversal.yaml
     dependencies:
     - master_orchestrator
     - entry_executor_smc
@@ -166,7 +166,7 @@ strategy_agents:
     type: session_trading
   smc_liquidity_trap:
     class: SMCLiquidityTrapAgent
-    config_file: configs/strategies/smc_liquidity_trap.yaml
+    config_file: config/strategies/smc_liquidity_trap.yaml
     dependencies:
     - master_orchestrator
     - liquidity_sniper
@@ -186,7 +186,7 @@ strategy_agents:
     type: smc_execution
   wyckoff_phase_cycle:
     class: WyckoffPhaseCycleAgent
-    config_file: configs/strategies/wyckoff_phase_cycle.yaml
+    config_file: config/strategies/wyckoff_phase_cycle.yaml
     dependencies:
     - master_orchestrator
     - session_state_manager

--- a/config/strategies/micro_wyckoff_event.yaml
+++ b/config/strategies/micro_wyckoff_event.yaml
@@ -1,0 +1,3 @@
+strategy:
+  name: "Micro Wyckoff Event"
+  description: "Placeholder config for micro Wyckoff event strategy."

--- a/config/strategies/orderflow_anomaly.yaml
+++ b/config/strategies/orderflow_anomaly.yaml
@@ -1,0 +1,3 @@
+strategy:
+  name: "Orderflow Anomaly"
+  description: "Placeholder config for orderflow anomaly strategy."

--- a/config/strategies/protection_reentry.yaml
+++ b/config/strategies/protection_reentry.yaml
@@ -1,0 +1,3 @@
+strategy:
+  name: "Protection Reentry"
+  description: "Placeholder config for protection reentry strategy."

--- a/config/strategies/session_sweep_reversal.yaml
+++ b/config/strategies/session_sweep_reversal.yaml
@@ -1,0 +1,3 @@
+strategy:
+  name: "Session Sweep Reversal"
+  description: "Placeholder config for session sweep reversal strategy."

--- a/config/strategies/smc_liquidity_trap.yaml
+++ b/config/strategies/smc_liquidity_trap.yaml
@@ -1,0 +1,6 @@
+strategy:
+  name: "SMC Liquidity Trap"
+  risk_per_trade: "2.5%"
+  max_positions: 2
+  timeframes: ["M1", "M5"]
+  triggers: ["liquidity_trap_detected"]

--- a/config/strategies/wyckoff_phase_cycle.yaml
+++ b/config/strategies/wyckoff_phase_cycle.yaml
@@ -1,0 +1,3 @@
+strategy:
+  name: "Wyckoff Phase Cycle"
+  description: "Placeholder config for Wyckoff phase cycle strategy."


### PR DESCRIPTION
## Summary
- add missing `config/strategies` directory with placeholder strategy configs
- update all `config_file` paths to `config/strategies/...`
- fix README snippet to reference the new path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68549e43e780832eb1b3b1a1eee1d815