### PR TITLE
Update autostart default config

### DIFF
--- a/_to_integrate/ncos_autostart.py
+++ b/_to_integrate/ncos_autostart.py
@@ -29,7 +29,7 @@ class NCOSAutoStartManager:
     Integrates all components including the new Predictive Engine
     """
 
-    def __init__(self, config_file: str = "AUTOSTART_v21.md", mode: str = "production"):
+    def __init__(self, config_file: str = "AUTOSTART_v21.yaml", mode: str = "production"):
         self.config_file = config_file
         self.mode = mode
         self.boot_time = datetime.now()


### PR DESCRIPTION
## Summary
- default to `AUTOSTART_v21.yaml` when creating `NCOSAutoStartManager`

## Testing
- `pytest -k ncos_autostart -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6854a7f50fe4832eb232cfa083a5bc35