### PR TITLE
Add persistent vector store

### DIFF
--- a/enhanced_core_orchestrator.py
+++ b/enhanced_core_orchestrator.py
@@ -18,6 +18,7 @@ import pandas as pd
 # Import our new engines
 from smc_analysis_engine import ncOScoreSMCEngine
 from enhanced_vector_engine import ncOScoreVectorEngine, BrownVectorStoreIntegration
+from vector_store import VectorStore
 from liquidity_analysis_engine import ncOScoreLiquidityEngine
 
 class MountPoint(Enum):
@@ -80,6 +81,8 @@ class ncOScoreEnhancedOrchestrator:
         self.vector_engine = None
         self.liquidity_engine = None
         self.brown_vector_store = None
+        self.vector_store = None
+        self._vector_store_task = None
 
     def _load_config(self, config_path: Optional[str]) -> Dict:
         """Load enhanced configuration"""
@@ -163,12 +166,16 @@ class ncOScoreEnhancedOrchestrator:
             self.smc_engine = ncOScoreSMCEngine(self.session_state)
             self.logger.info("✅ SMC Analysis Engine initialized")
 
-            # Initialize Vector Engine
+            # Initialize Vector Store and Engine
+            store_path = MountPoint.resolve(self.session_state.mount_points["session"]) / "vector_store.json"
+            self.vector_store = VectorStore(store_path)
             self.vector_engine = ncOScoreVectorEngine(
-                dimensions=1536, 
-                memory_manager=self.session_state
+                dimensions=1536,
+                memory_manager=self.session_state,
+                vector_store=self.vector_store,
             )
             self.logger.info("✅ Vector Engine initialized")
+            self._vector_store_task = asyncio.create_task(self._autosave_vector_store())
 
             # Initialize Brown Vector Store
             self.brown_vector_store = BrownVectorStoreIntegration(self.vector_engine)
@@ -488,6 +495,17 @@ class ncOScoreEnhancedOrchestrator:
             "trading": trading_status,
             "engines": engine_status
         }
+
+    async def _autosave_vector_store(self, interval: int = 300) -> None:
+        """Periodically save the vector store to disk."""
+        while True:
+            await asyncio.sleep(interval)
+            if self.vector_store:
+                try:
+                    self.vector_store.save()
+                    self.logger.info("💾 Vector store autosaved")
+                except Exception as e:  # pragma: no cover - safeguard
+                    self.logger.error(f"Vector store autosave failed: {e}")
 
     # Additional helper methods for file detection
     def _detect_file_type(self, file_path: str) -> str:

--- a/enhanced_vector_engine.py
+++ b/enhanced_vector_engine.py
@@ -4,24 +4,32 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from vector_store import VectorStore
+
 
 class ncOScoreVectorEngine:
-    """Simple placeholder vector engine."""
+    """Simple placeholder vector engine with persistent storage."""
 
-    def __init__(self, dimensions: int, memory_manager: Any | None = None) -> None:
+    def __init__(
+        self,
+        dimensions: int,
+        memory_manager: Any | None = None,
+        vector_store: VectorStore | None = None,
+    ) -> None:
         self.dimensions = dimensions
         self.memory_manager = memory_manager
-        self.vectors: Dict[str, List[float]] = {}
+        self.store = vector_store or VectorStore()
 
     async def embed_market_data(self, df: Any, key: str) -> Dict[str, Any]:  # pragma: no cover - stub
-        self.vectors[key] = [0.0] * self.dimensions
+        """Embed market data and store the resulting vector."""
+        self.store.add_vector(key, [0.0] * self.dimensions)
         return {"vector_id": key, "status": "success"}
 
     async def pattern_matching(self, df: Any, pattern: str) -> Dict[str, Any]:  # pragma: no cover - stub
         return {"status": "success", "similar_patterns": []}
 
     def get_vector_store_stats(self) -> Dict[str, Any]:  # pragma: no cover - stub
-        return {"total_vectors": len(self.vectors)}
+        return self.store.get_stats()
 
 
 class BrownVectorStoreIntegration:

--- a/vector_store.py
+++ b/vector_store.py
@@ -1,0 +1,61 @@
+"""Simple persistent vector store for ncOS."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Any
+
+
+class VectorStore:
+    """A lightweight vector store with disk persistence."""
+
+    def __init__(self, store_path: str | Path = "vector_store.json") -> None:
+        self.path = Path(store_path)
+        self.vectors: Dict[str, List[float]] = {}
+        self.stats: Dict[str, Any] = {
+            "total_vectors": 0,
+            "last_loaded": None,
+            "last_saved": None,
+        }
+        self.load()
+
+    def add_vector(self, key: str, vector: List[float]) -> None:
+        """Add or update a vector."""
+        self.vectors[key] = vector
+        self.stats["total_vectors"] = len(self.vectors)
+
+    def get_vector(self, key: str) -> List[float] | None:
+        """Retrieve a vector by key."""
+        return self.vectors.get(key)
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Return store statistics."""
+        disk_size = self.path.stat().st_size if self.path.exists() else 0
+        stats = dict(self.stats)
+        stats["disk_usage_bytes"] = disk_size
+        return stats
+
+    def load(self) -> None:
+        """Load vectors from disk if available."""
+        if self.path.exists():
+            try:
+                with open(self.path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                self.vectors = data.get("vectors", {})
+                self.stats.update(data.get("stats", {}))
+            except Exception as exc:  # pragma: no cover - safeguard
+                print(f"Error loading vector store: {exc}")
+        self.stats["total_vectors"] = len(self.vectors)
+        self.stats["last_loaded"] = datetime.now().isoformat()
+
+    def save(self) -> None:
+        """Persist vectors to disk."""
+        try:
+            data = {"vectors": self.vectors, "stats": self.stats}
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            self.stats["last_saved"] = datetime.now().isoformat()
+        except Exception as exc:  # pragma: no cover - safeguard
+            print(f"Error saving vector store: {exc}")


### PR DESCRIPTION
## Summary
- implement `VectorStore` with simple JSON persistence
- integrate vector store into the vector engine
- load the store in the orchestrator and autosave periodically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6854acb93084832ebb7f31b8a9f97d8d