### PR TITLE
Add history limit to risk analyzer

### DIFF
--- a/cross_domain_risk_analyzer.py
+++ b/cross_domain_risk_analyzer.py
@@ -1,5 +1,12 @@
-"""Cross-Domain Risk Analyzer for Bootstrap v14
-Analyzes and correlates risks across deployment and trading domains
+"""Cross-Domain Risk Analyzer for Bootstrap v14.
+
+Analyzes and correlates risks across deployment and trading domains.
+
+Parameters
+----------
+history_limit : int, optional
+    Maximum number of risk scores to keep in ``risk_history``. Defaults to
+    ``100``.
 """
 
 from __future__ import annotations
@@ -31,7 +38,8 @@ class RiskCorrelation:
 class CrossDomainRiskAnalyzer:
     """Analyze and correlate risks across multiple operational domains."""
 
-    def __init__(self) -> None:
+    def __init__(self, history_limit: int = 100) -> None:
+        self.history_limit = history_limit
         self.risk_factors: Dict[str, List[RiskFactor]] = {
             "deployment": [],
             "trading": [],
@@ -119,9 +127,13 @@ class CrossDomainRiskAnalyzer:
 
         overall_risk = float(np.mean(list(domain_scores.values()))) * correlation_multiplier
         overall_risk = min(overall_risk, 1.0)
+        rounded_risk = round(overall_risk, 3)
+        self.risk_history.append(rounded_risk)
+        if len(self.risk_history) > self.history_limit:
+            self.risk_history[:] = self.risk_history[-self.history_limit:]
 
         return {
-            "overall_risk": round(overall_risk, 3),
+            "overall_risk": rounded_risk,
             "domain_risks": domain_scores,
             "high_correlations": len([c for c in self.correlations if c.correlation_strength > 0.7]),
             "mitigation_available": sum(

--- a/ncos_risk_engine.py
+++ b/ncos_risk_engine.py
@@ -367,9 +367,7 @@ def get_unified_risk_score() -> Dict[str, Any]:
             "risk_trend": "stable",
         }
 
-    result = _cross_domain_analyzer.get_unified_risk_score()
-    _cross_domain_analyzer.risk_history.append(result["overall_risk"])
-    return result
+    return _cross_domain_analyzer.get_unified_risk_score()
 
 
 def get_mitigation_recommendations() -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- allow configuring the number of stored historical risk values
- trim history in `get_unified_risk_score`
- update module docs

## Testing
- `pytest tests/test_cross_domain_risk_analyzer.py::TestCrossDomainRiskAnalyzerIntegration::test_unified_risk_score_and_recommendations -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_6854aeb974d8832eabf5fccd71afef19