### PR TITLE
Fix console script and package metadata

### DIFF
--- a/ncOS/enhanced_cli.py
+++ b/ncOS/enhanced_cli.py
@@ -305,3 +305,22 @@ Features:
   ✓ Multi-agent consensus
   ✓ Session auto-save
         """
+
+
+async def _run_cli() -> None:
+    """Launch the enhanced CLI after bootstrapping the system."""
+    from ..launch_ncos_v21_7_1_enhanced_complete import (
+        launch_ncos_enhanced_complete,
+    )
+
+    orchestrator = await launch_ncos_enhanced_complete(None)
+    cli = EnhancedLLMCLI(orchestrator)
+    await cli.start()
+
+
+def main() -> None:
+    """Entry point for the ``ncos`` console script."""
+    asyncio.run(_run_cli())
+
+
+__all__ = ["EnhancedLLMCLI", "main"]

--- a/setup_v21.7.1.py
+++ b/setup_v21.7.1.py
@@ -20,7 +20,7 @@ VERSION = "21.7.1"
 DESCRIPTION = "Neural Cognitive Operating System - Complete AI Trading Ecosystem"
 
 setup(
-    name="ncos-phoenix-mesh",
+    name="ncOS",
     version=VERSION,
     author="NCOS Team",
     author_email="team@ncos.ai",
@@ -81,15 +81,15 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "ncos=ncos.cli:main",
-            "ncos-launch=ncos.agents.master_orchestrator:main",
-            "ncos-validate=ncos.utils.validation:main",
-            "ncos-monitor=ncos.monitoring.dashboard:main",
+            "ncos=ncOS.enhanced_cli:main",
+            "ncos-launch=ncOS.agents.master_orchestrator:main",
+            "ncos-validate=ncOS.utils.validation:main",
+            "ncos-monitor=ncOS.monitoring.dashboard:main",
         ],
     },
     include_package_data=True,
     package_data={
-        "ncos": [
+        "ncOS": [
             "configs/*.yaml",
             "configs/*.json",
             "configs/*.toml",


### PR DESCRIPTION
## Summary
- update console script to use the enhanced CLI
- set package name to **ncOS** and update package data path
- add runnable `main` function in `ncOS.enhanced_cli`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6854b29e843c832eb775c5e926c0741b