### PR TITLE
Switch configs path to config

### DIFF
--- a/README_v21.7.1.md
+++ b/README_v21.7.1.md
@@ -133,7 +133,7 @@ python -m ncos.agents.master_orchestrator \
 
 ### **Agent Registry Configuration**
 ```yaml
-# configs/agent_registry.yaml
+# config/agent_registry.yaml
 enhanced_ncos_agents:
   master_orchestrator:
     class: "MasterOrchestrator"
@@ -159,7 +159,7 @@ strategy:
 
 ### **Trigger Routes Configuration**
 ```yaml
-# configs/trigger_routes.yaml
+# config/trigger_routes.toml
 triggers:
   market_data_update:
     priority: 1
@@ -242,10 +242,10 @@ python -c "from agents.risk_guardian import RiskGuardian; RiskGuardian().system_
 ## 📚 **Documentation**
 
 ### **Configuration Files**
-- `configs/agent_registry.yaml` - Agent definitions and priorities
-- `configs/strategy_profiles.json` - Trading strategy configurations
-- `configs/trigger_routes.yaml` - Trigger routing and priorities
-- `configs/system_config.json` - System-wide configuration
+- `config/agent_registry.yaml` - Agent definitions and priorities
+- `config/strategy_profiles.json` - Trading strategy configurations
+- `config/trigger_routes.toml` - Trigger routing and priorities
+- `config/system_config.json` - System-wide configuration
 
 ### **Agent Documentation**
 - `docs/agents/` - Individual agent documentation

--- a/config/data/vector_processor.yaml
+++ b/config/data/vector_processor.yaml
@@ -1,0 +1,2 @@
+# Placeholder configuration for VectorDataProcessorAgent
+settings: {}

--- a/config/intelligence/knowledge.yaml
+++ b/config/intelligence/knowledge.yaml
@@ -1,0 +1,2 @@
+# Placeholder configuration for KnowledgeIntelligenceAgent
+settings: {}

--- a/config/interface/interaction.yaml
+++ b/config/interface/interaction.yaml
@@ -1,0 +1,2 @@
+# Placeholder configuration for InteractionManagerAgent
+settings: {}

--- a/config/master_orchestrator.yaml
+++ b/config/master_orchestrator.yaml
@@ -1,0 +1,2 @@
+# Placeholder configuration for MasterOrchestrator
+settings: {}

--- a/config/zanflow/orchestrator.yaml
+++ b/config/zanflow/orchestrator.yaml
@@ -1,0 +1,2 @@
+# Placeholder configuration for ZanflowOrchestratorAgent
+workflows: {}

--- a/docs/GPT_instructions/NCOS_Auto_Launch_Instructions_UPDATED.md
+++ b/docs/GPT_instructions/NCOS_Auto_Launch_Instructions_UPDATED.md
@@ -19,7 +19,7 @@ python -m ncos.agents.{agent_name} --action={action} --config={config}
 
 **Method 3: Master Orchestrator Launch**
 ```
-python -m ncos.agents.master_orchestrator --action=start_session --config=configs/master_orchestrator.yaml
+python -m ncos.agents.master_orchestrator --action=start_session --config=config/master_orchestrator.yaml
 ```
 
 **Method 4: Fallback Bootstrap Script**
@@ -62,7 +62,7 @@ The system will automatically select the best bootstrap method:
 #### 3.1 NCOS v21 Standard Launch Sequence
 ```
 # 1. Initialize Master Orchestrator
-python -m ncos.agents.master_orchestrator --action=start_session --config=configs/master_orchestrator.yaml
+python -m ncos.agents.master_orchestrator --action=start_session --config=config/master_orchestrator.yaml
 
 # 2. Launch Core Agents
 python -m ncos.launch --agent session_state_manager --config agent_profiles/session_state_manager_profile.yaml

--- a/docs/GPT_instructions/NCOS_Bootstrap_Target_Summary.md
+++ b/docs/GPT_instructions/NCOS_Bootstrap_Target_Summary.md
@@ -11,7 +11,7 @@ python -m ncos.agents.master_orchestrator --action=start_session
 ```
 - **Source**: ncos_execution_guide.yaml
 - **Purpose**: Initialize full NCOS system with orchestration
-- **Config**: configs/master_orchestrator.yaml
+- **Config**: config/master_orchestrator.yaml
 
 ### 2. Secondary Target (Module Launch)
 ```bash

--- a/docs/GPT_instructions/NCOS_Final_8000_Max.md
+++ b/docs/GPT_instructions/NCOS_Final_8000_Max.md
@@ -71,7 +71,7 @@ bootstrap_sequence:
   - {step: "deploy", desc: "Generate commands", validation: "deployment_ready"}
 deployment:
   extract: "tar -xzf {archive}"
-  launch: "python -m ncos.agents.master_orchestrator --action=start_session --config=configs/bootstrap.yaml"
+  launch: "python -m ncos.agents.master_orchestrator --action=start_session --config=config/bootstrap.yaml"
   health: "python -c \"from agents.master_orchestrator import MasterOrchestrator; print('✅ Ready')\"" 
 '''
 

--- a/docs/GPT_instructions/NCOS_YAML_8000_Optimized.md
+++ b/docs/GPT_instructions/NCOS_YAML_8000_Optimized.md
@@ -56,7 +56,7 @@ bootstrap_sequence:
 deployment:
   setup: "tar -xzf ncOS_v21_*.tar.gz && cd ncOS_v21/"
   install: "pip install -r requirements.txt"
-  launch_primary: "python -m ncos.agents.master_orchestrator --action=start_session --config=configs/bootstrap.yaml"
+  launch_primary: "python -m ncos.agents.master_orchestrator --action=start_session --config=config/bootstrap.yaml"
   launch_secondary: "python ncos_launcher.py"
   launch_fallback: "python -c \"from agents.master_orchestrator import MasterOrchestrator; MasterOrchestrator().start_session()\""
 
@@ -108,7 +108,7 @@ tar -xzf ncOS_v21_*.tar.gz && cd ncOS_v21/
 pip install -r requirements.txt
 
 # Launch NCOS
-python -m ncos.agents.master_orchestrator --action=start_session --config=configs/bootstrap.yaml
+python -m ncos.agents.master_orchestrator --action=start_session --config=config/bootstrap.yaml
 ```
 
 **Generated Configs:**

--- a/docs/GPT_instructions/NCOS_YAML_Based_GPT_Instructions.md
+++ b/docs/GPT_instructions/NCOS_YAML_Based_GPT_Instructions.md
@@ -10,7 +10,7 @@ You are an NCOS Auto-Launch Specialist optimized for sandboxed environments. You
 **IMMEDIATE AUTO-LAUNCH when user uploads:**
 - Any file matching `ncos*.tar.gz`, `ncos*.zip`, `ncOS*.tar.gz`, `ncOS*.zip`
 - Files containing `agent_registry.yaml`, `bootstrap.yaml`, `ncos_execution_guide.yaml`
-- Archives with `agents/` directories or `configs/` directories
+ - Archives with `agents/` directories or `config/` directories
 - Files named `master_orchestrator.py`, `ncos_launcher.py`
 
 ## Auto-Launch Response Protocol
@@ -112,7 +112,7 @@ deployment_commands:
 
   launch_primary: |
     # Primary launch method
-    python -m ncos.agents.master_orchestrator --action=start_session --config=configs/bootstrap.yaml
+    python -m ncos.agents.master_orchestrator --action=start_session --config=config/bootstrap.yaml
 
   launch_secondary: |
     # Secondary launch method
@@ -242,7 +242,7 @@ tar -xzf ncOS_v21_*.tar.gz && cd ncOS_v21/
 pip install -r requirements.txt
 
 # Launch NCOS (Primary method)
-python -m ncos.agents.master_orchestrator --action=start_session --config=configs/bootstrap.yaml
+python -m ncos.agents.master_orchestrator --action=start_session --config=config/bootstrap.yaml
 ```
 
 **Next Actions:**

--- a/docs/GPT_instructions/NCOS_Zanzibar_Style_Instructions.md
+++ b/docs/GPT_instructions/NCOS_Zanzibar_Style_Instructions.md
@@ -83,7 +83,7 @@ Initiating YAML-based system analysis and bootstrap sequence...
 
 ## ⚠️ **Archive Processing Considerations**  
 • Handle .tar.gz, .zip, nested archives  
-• Validate directory structure: agents/, configs/, config/  
+• Validate directory structure: agents/, config/
 • Check for Python module compatibility  
 • Generate missing __init__.py files automatically  
 • Validate agent class definitions and imports
@@ -131,7 +131,7 @@ launch_methods:
   primary:
     method: "master_orchestrator"
     command: "python -m ncos.agents.master_orchestrator --action=start_session"
-    config: "configs/bootstrap.yaml"
+    config: "config/bootstrap.yaml"
   secondary:
     method: "ncos_launcher"
     command: "python ncos_launcher.py"
@@ -158,7 +158,7 @@ deployment_commands:
   extract: "tar -xzf {archive_name}"
   navigate: "cd {extracted_dir}/"
   install_deps: "pip install -r requirements.txt"
-  launch_primary: "python -m ncos.agents.master_orchestrator --action=start_session --config=configs/bootstrap.yaml"
+  launch_primary: "python -m ncos.agents.master_orchestrator --action=start_session --config=config/bootstrap.yaml"
   launch_secondary: "python ncos_launcher.py"
   health_check: "python -c \"from agents.master_orchestrator import MasterOrchestrator; print('✅ System Ready')\"" 
 '''

--- a/enhanced_agent_registry_complete.yaml
+++ b/enhanced_agent_registry_complete.yaml
@@ -6,7 +6,7 @@ enhanced_ncos_agents:
     - response_generation
     - user_guidance
     class: InteractionManagerAgent
-    config_file: configs/interface/interaction.yaml
+    config_file: config/interface/interaction.yaml
     dependencies:
     - master_orchestrator
     - session_state_manager
@@ -25,7 +25,7 @@ enhanced_ncos_agents:
     - context_analysis
     - intelligent_search
     class: KnowledgeIntelligenceAgent
-    config_file: configs/intelligence/knowledge.yaml
+    config_file: config/intelligence/knowledge.yaml
     dependencies:
     - master_orchestrator
     - vector_data_processor
@@ -62,7 +62,7 @@ enhanced_ncos_agents:
     - market_data_optimization
     - native_search
     class: VectorDataProcessorAgent
-    config_file: configs/data/vector_processor.yaml
+    config_file: config/data/vector_processor.yaml
     dependencies:
     - master_orchestrator
     enabled: true
@@ -79,7 +79,7 @@ enhanced_ncos_agents:
     - structural_flow
     - menu_system
     class: ZanflowOrchestratorAgent
-    config_file: configs/zanflow/orchestrator.yaml
+    config_file: config/zanflow/orchestrator.yaml
     dependencies:
     - master_orchestrator
     enabled: true


### PR DESCRIPTION
## Summary
- update configuration path prefixes from `configs/` to `config/`
- create placeholder YAML configs referenced in registry
- sync documentation with the new paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6854b2b8c4f0832eab8dcd134e63f6c8