### PR TITLE
Fix setup config path and add console scripts

### DIFF
--- a/setup_v21.7.1.py
+++ b/setup_v21.7.1.py
@@ -81,16 +81,19 @@ setup(
     },
     entry_points={
         "console_scripts": [
+            "ncos=ncOS.ncos_launcher:main",
+            "ncos-cli=ncOS.enhanced_cli:main",
+            "add-structure=scripts.add_structure:main",
         ],
     },
     include_package_data=True,
     package_data={
         "ncOS": [
-            "configs/*.yaml",
-            "configs/*.json",
-            "configs/*.toml",
-            "configs/**/*.yaml",
-            "configs/**/*.json",
+            "config/*.yaml",
+            "config/*.json",
+            "config/*.toml",
+            "config/**/*.yaml",
+            "config/**/*.json",
             "templates/*.yaml",
             "templates/*.json",
             "schemas/*.json",


### PR DESCRIPTION
## Summary
- fix config path references in packaging script
- add console scripts for launcher, CLI and structure helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6854b5bfc9a0832eb357b44ccbc47afe