### PR TITLE
Add config stubs for strategy agents

### DIFF
--- a/config/divergence_strategy_agent_config.yaml
+++ b/config/divergence_strategy_agent_config.yaml
@@ -1,0 +1,1 @@
+settings: {}

--- a/config/micro_wyckoff_event_config.yaml
+++ b/config/micro_wyckoff_event_config.yaml
@@ -1,0 +1,1 @@
+settings: {}

--- a/config/orderflow_anomaly_config.yaml
+++ b/config/orderflow_anomaly_config.yaml
@@ -1,0 +1,1 @@
+settings: {}

--- a/config/protection_reentry_config.yaml
+++ b/config/protection_reentry_config.yaml
@@ -1,0 +1,1 @@
+settings: {}

--- a/config/session_sweep_reversal_config.yaml
+++ b/config/session_sweep_reversal_config.yaml
@@ -1,0 +1,1 @@
+settings: {}

--- a/config/smc_liquidity_trap_config.yaml
+++ b/config/smc_liquidity_trap_config.yaml
@@ -1,0 +1,1 @@
+settings: {}

--- a/config/wyckoff_phase_cycle_config.yaml
+++ b/config/wyckoff_phase_cycle_config.yaml
@@ -1,0 +1,1 @@
+settings: {}

--- a/ncOS/ncos_launcher.py
+++ b/ncOS/ncos_launcher.py
@@ -88,11 +88,15 @@ def verify_schema_mapping():
     with open(registry_path, 'r') as f:
         registry = yaml.safe_load(f) or {}
     missing = []
-    for agent in registry.get('agents', {}):
-        cfg_path = Path('config') / f"{agent.lower()}_config.yaml"
-        if not cfg_path.exists():
-            print(f"⚠️  Warning: Config file for '{agent}' not found at {cfg_path}")
-            missing.append(agent)
+    # Validate config files for both core and strategy agents
+    for section in ("agents", "strategy_agents"):
+        for agent in registry.get(section, {}):
+            cfg_path = Path('config') / f"{agent.lower()}_config.yaml"
+            if not cfg_path.exists():
+                print(
+                    f"⚠️  Warning: Config file for '{agent}' not found at {cfg_path}"
+                )
+                missing.append(agent)
 
     if missing:
         print(f"❌ Error: {len(missing)} configuration file(s) missing for registered agents")


### PR DESCRIPTION
## Summary
- add placeholder config files for strategy agents
- verify config presence for both core and strategy agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6854b5c18800832e80fe56abb377cb7c