### PR TITLE
Fix missing agents in configuration

### DIFF
--- a/README_v21.7.1.md
+++ b/README_v21.7.1.md
@@ -134,16 +134,21 @@ python -m ncOS.ncos_launcher \
 ### **Agent Registry Configuration**
 ```yaml
 # config/agent_registry.yaml
-enhanced_ncos_agents:
+agents:
   master_orchestrator:
+    module: "master_orchestrator"
     class: "MasterOrchestrator"
     priority: 1
-    enhancements: ["zanflow_integration", "vector_data_access"]
 
   zanflow_orchestrator:
-    class: "ZanflowOrchestratorAgent"
+    module: "zanflow_orchestrator"
+    class: "ZanflowOrchestrator"
     priority: 3
-    capabilities: ["prompt_engineering", "logical_blocks"]
+
+  vector_data_processor:
+    module: "vector_data_processor"
+    class: "VectorDataProcessor"
+    priority: 2
 ```
 
 ### **Strategy Configuration**

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -5,3 +5,7 @@ from .session_sweep_reversal import SessionSweepReversalAgent
 from .smc_liquidity_trap import SMCLiquidityTrapAgent
 from .smc_master_agent import SMCMasterAgent
 from .wyckoff_phase_cycle import WyckoffPhaseCycleAgent
+from .interaction_manager import InteractionManager
+from .zanflow_orchestrator import ZanflowOrchestrator
+from .vector_data_processor import VectorDataProcessor
+from .knowledge_intelligence import KnowledgeIntelligence

--- a/agents/interaction_manager.py
+++ b/agents/interaction_manager.py
@@ -1,0 +1,23 @@
+"""Simple Interaction Manager agent for handling user interactions."""
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+@dataclass
+class InteractionManagerConfig:
+    agent_id: str = "interaction_manager"
+    enabled: bool = True
+    log_level: str = "INFO"
+
+class InteractionManager:
+    """Minimal interaction management agent."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = InteractionManagerConfig(**(config or {}))
+        self.logger = logging.getLogger(self.config.agent_id)
+        self.logger.setLevel(getattr(logging, self.config.log_level))
+
+    async def handle(self, message: str) -> Dict[str, Any]:
+        """Return a simple acknowledgement for the provided message."""
+        self.logger.debug("Handling message: %s", message)
+        return {"ack": True, "message": message}

--- a/agents/knowledge_intelligence.py
+++ b/agents/knowledge_intelligence.py
@@ -1,0 +1,23 @@
+"""Knowledge Intelligence agent for simple knowledge lookups."""
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+@dataclass
+class KnowledgeIntelligenceConfig:
+    agent_id: str = "knowledge_intelligence"
+    enabled: bool = True
+    log_level: str = "INFO"
+
+class KnowledgeIntelligence:
+    """Provide minimal knowledge base lookup functionality."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = KnowledgeIntelligenceConfig(**(config or {}))
+        self.logger = logging.getLogger(self.config.agent_id)
+        self.logger.setLevel(getattr(logging, self.config.log_level))
+
+    async def query(self, question: str) -> Dict[str, Any]:
+        """Return a canned response for a question."""
+        self.logger.debug("Received question: %s", question)
+        return {"question": question, "answer": "unknown"}

--- a/agents/vector_data_processor.py
+++ b/agents/vector_data_processor.py
@@ -1,0 +1,23 @@
+"""Vector Data Processor agent for lightweight vector operations."""
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+@dataclass
+class VectorDataProcessorConfig:
+    agent_id: str = "vector_data_processor"
+    enabled: bool = True
+    log_level: str = "INFO"
+
+class VectorDataProcessor:
+    """Simple processor for vector-based data."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = VectorDataProcessorConfig(**(config or {}))
+        self.logger = logging.getLogger(self.config.agent_id)
+        self.logger.setLevel(getattr(logging, self.config.log_level))
+
+    async def process(self, vector: List[float]) -> Dict[str, Any]:
+        """Return the vector length as a basic operation."""
+        self.logger.debug("Processing vector of length %d", len(vector))
+        return {"length": len(vector)}

--- a/agents/zanflow_orchestrator.py
+++ b/agents/zanflow_orchestrator.py
@@ -1,0 +1,23 @@
+"""Stub Zanflow Orchestrator agent implementing basic workflow logic."""
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+@dataclass
+class ZanflowOrchestratorConfig:
+    agent_id: str = "zanflow_orchestrator"
+    enabled: bool = True
+    log_level: str = "INFO"
+
+class ZanflowOrchestrator:
+    """Minimal agent to orchestrate simple workflows."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = ZanflowOrchestratorConfig(**(config or {}))
+        self.logger = logging.getLogger(self.config.agent_id)
+        self.logger.setLevel(getattr(logging, self.config.log_level))
+
+    async def run_workflow(self, steps: List[str]) -> Dict[str, Any]:
+        """Return a summary of executed steps."""
+        self.logger.debug("Running workflow: %s", steps)
+        return {"executed": steps}

--- a/config/agent_registry.yaml
+++ b/config/agent_registry.yaml
@@ -92,6 +92,36 @@ agents:
     class: "DriftDetectionAgent"
     config_file: "config/drift_detection.yaml"
     enabled: true
+
+  master_orchestrator:
+    module: "master_orchestrator"
+    class: "MasterOrchestrator"
+    description: "Coordinates workflows across agents"
+
+  smc_master_agent:
+    module: "smc_master_agent"
+    class: "SMCMasterAgent"
+    description: "Core SMC analysis engine"
+
+  interaction_manager:
+    module: "interaction_manager"
+    class: "InteractionManager"
+    description: "Handles user interaction flows"
+
+  zanflow_orchestrator:
+    module: "zanflow_orchestrator"
+    class: "ZanflowOrchestrator"
+    description: "Executes Zanflow logical workflows"
+
+  vector_data_processor:
+    module: "vector_data_processor"
+    class: "VectorDataProcessor"
+    description: "Processes vector-based market data"
+
+  knowledge_intelligence:
+    module: "knowledge_intelligence"
+    class: "KnowledgeIntelligence"
+    description: "Provides simple knowledge lookups"
 strategy_agents:
   micro_wyckoff_event:
     class: MicroWyckoffEventAgent


### PR DESCRIPTION
## Summary
- stub agent implementations for vector data processing, zanflow orchestration, interaction management and knowledge lookups
- register the new agents in `agent_registry.yaml`
- document new entries in `README_v21.7.1.md`
- export new agent classes from `agents/__init__.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6854b8c99c80832ea547900a012229b9