### PR TITLE
Fix typing import

### DIFF
--- a/_21.7.2_to_deploy/voice_api_routes.py
+++ b/_21.7.2_to_deploy/voice_api_routes.py
@@ -5,7 +5,7 @@ Voice Command API Extensions for ZBAR System
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 import speech_recognition as sr
 from enhanced_menu_system import EnhancedMenuSystem
 


### PR DESCRIPTION
## Summary
- add `List` to the typing imports used in voice_api_routes

## Testing
- `pytest -q` *(fails: No module named 'requests', 'pandas', 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_685591982238832eab7254f90bb65c15