### PR TITLE
Update plugin API version strings

### DIFF
--- a/_21.7.2_to_deploy/ncos_openapi.json
+++ b/_21.7.2_to_deploy/ncos_openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "NCOS Live Market Data API",
-    "version": "21.7.1",
+    "version": "21.7.2",
     "description": "Provides live market data for stocks, crypto, and forex, powered by the NCOS system."
   },
   "paths": {

--- a/_21.7.2_to_deploy/plugin_api_backend.py
+++ b/_21.7.2_to_deploy/plugin_api_backend.py
@@ -9,7 +9,7 @@ import json
 app = FastAPI(
     title="NCOS Live Market Data API",
     description="Provides live market data for stocks, crypto, and forex, powered by the NCOS system.",
-    version="21.7.1"
+    version="21.7.2"
 )
 
 # Allow CORS for development and for the LLM platform to access the API

--- a/ncos_plugin/ncos_openapi.json
+++ b/ncos_plugin/ncos_openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "NCOS Live Market Data API",
-    "version": "21.7.1",
+    "version": "21.7.2",
     "description": "Provides live market data for stocks, crypto, and forex, powered by the NCOS system."
   },
   "paths": {

--- a/ncos_plugin/plugin_api_backend.py
+++ b/ncos_plugin/plugin_api_backend.py
@@ -11,7 +11,7 @@ from fastapi import Query
 # Import your custom Finnhub client
 from ncos_plugin.finnhub_data_fetcher import finnhub_client
 
-app = FastAPI(title="NCOS Live Market Data API", version="21.7.1")
+app = FastAPI(title="NCOS Live Market Data API", version="21.7.2")
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- bump plugin API version to 21.7.2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests' et al.)*

------
https://chatgpt.com/codex/tasks/task_b_6855973f1340832e8c201ee8ef0f7e83