### PR TITLE
Add voice processing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ on `pandas`, `numpy` and all other packages listed in `requirements.txt`:
 
 ```bash
 pip install -r requirements.txt
+python -m spacy download en_core_web_sm
 ```
 
 For additional test utilities install the development requirements as well:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ uvicorn[standard]
 yfinance
 finnhub-python==2.4.23
 requests
+spacy
+speechrecognition
+pyaudio
+streamlit

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -100,6 +100,10 @@ numpy==1.24.3
 pydantic==2.0.3
 pyarrow==12.0.1
 python-dateutil==2.8.2
+spacy
+speechrecognition
+pyaudio
+streamlit
 EOF
 
     # Install dependencies


### PR DESCRIPTION
## Summary
- add spacy, speechrecognition, pyaudio, streamlit dependencies
- include them in deploy script
- document `en_core_web_sm` model for spaCy in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_685597a1de70832eacb0e25d03d285f8