### PR TITLE
Remove unused import

### DIFF
--- a/_21.7.2_to_deploy/setup_ncos.py
+++ b/_21.7.2_to_deploy/setup_ncos.py
@@ -7,7 +7,6 @@ Automatically creates directory structure and initial configuration
 import os
 import sys
 from pathlib import Path
-import shutil
 
 def setup_ncos_voice_journal():
     """Set up the NCOS Voice Journal System"""


### PR DESCRIPTION
## Summary
- clean up `setup_ncos.py` by dropping unused `shutil` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_68559c7d4918832eb6e63b26bacdc5e8