### PR TITLE
Fix voice command endpoint references

### DIFF
--- a/_21.7.2_verify/NCOS_Voice_Journal_Documentation.md
+++ b/_21.7.2_verify/NCOS_Voice_Journal_Documentation.md
@@ -496,7 +496,7 @@ zbar:
 
 ### Voice Endpoints
 
-#### POST /voice/process
+#### POST /voice/command
 Process a voice command and return structured result.
 
 **Request:**
@@ -885,7 +885,7 @@ For support or contributions, please refer to the project repository.
 - python core/ncos_voice_unified.py    → Voice interface
 
 📊 API Endpoints:
-- POST   /voice/process                → Process voice command
+- POST   /voice/command                → Process voice command
 - POST   /journal/append               → Add entry
 - GET    /journal/query                → Search entries
 - GET    /journal/recap/{session}      → Session summary

--- a/_21.7.2_verify/voice_api_routes.py
+++ b/_21.7.2_verify/voice_api_routes.py
@@ -1,6 +1,8 @@
 
-"""
-Voice Command API Extensions for ZBAR System
+"""Voice Command API Extensions for ZBAR System.
+
+Endpoints are mounted under the ``/voice`` prefix.  The primary route for
+processing a spoken or typed command is ``POST /voice/command``.
 """
 
 from fastapi import APIRouter, HTTPException


### PR DESCRIPTION
## Summary
- clarify voice endpoint in voice_api_routes docstring
- update documentation for POST /voice/command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6855aa1f38d0832ea4bc5c81d0a86e60