### PR TITLE
Use env vars for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ This package contains all components needed to run NCOS v21.
 cd scripts && python integration_bootstrap.py
 ```
 
+## Environment Variables
+
+Set API keys for external data sources before running the market data API:
+
+```bash
+export FINNHUB_API_KEY="your-finnhub-key"
+export TWELVE_DATA_API_KEY="your-twelvedata-key"
+```
+
 ## Running Tests
 
 Install the project dependencies before executing the test suite. The tests rely

--- a/_21.7.2_verify/NCOS_Plugin_README.md
+++ b/_21.7.2_verify/NCOS_Plugin_README.md
@@ -37,6 +37,15 @@ Then install them:
 pip install -r requirements.txt
 ```
 
+### Set API Keys
+
+Provide the required API keys as environment variables before launching the server:
+
+```bash
+export FINNHUB_API_KEY="your-finnhub-key"
+export TWELVE_DATA_API_KEY="your-twelvedata-key"
+```
+
 ### Step 2: Run Locally (for Testing)
 
 You can run the API server on your local machine to test its functionality.

--- a/ncos_plugin/finnhub_data_fetcher.py
+++ b/ncos_plugin/finnhub_data_fetcher.py
@@ -15,8 +15,8 @@ print("[DEBUG] ✅ finnhub_data_fetcher.py loaded and active")
 
 # --- Initialize Finnhub client ---
 finnhub_client = None
-# Use the provided API key, fallback to environment variable or placeholder
-FINNHUB_API_KEY = os.environ.get("FINNHUB_API_KEY", "d07lgo1r01qrslhp3q3gd07lgo1r01qrslhp3q40") # Using provided key
+# Finnhub API key must be provided via the FINNHUB_API_KEY environment variable
+FINNHUB_API_KEY = os.environ.get("FINNHUB_API_KEY")
 
 # Define base path for saving raw M1 data (consistent with data_pipeline)
 M1_SAVE_DIR = Path("tick_data/m1")

--- a/ncos_plugin/plugin_api_backend.py
+++ b/ncos_plugin/plugin_api_backend.py
@@ -5,6 +5,7 @@ import yfinance as yf
 from datetime import datetime
 from pathlib import Path
 import json
+import os
 import requests
 from fastapi import Query
 
@@ -23,7 +24,8 @@ app.add_middleware(
 
 BASE_DIR = Path(__file__).parent
 
-TWELVE_DATA_API_KEY = "6a29ddba6b9c4a91b969704fcc1b325f"  # or use os.environ.get("TWELVE_DATA_API_KEY")
+# Twelve Data API key should be provided via environment variable
+TWELVE_DATA_API_KEY = os.environ.get("TWELVE_DATA_API_KEY")
 
 def get_twelvedata_price(symbol: str):
     url = f"https://api.twelvedata.com/price?symbol={symbol}&apikey={TWELVE_DATA_API_KEY}"


### PR DESCRIPTION
## Summary
- load Twelve Data API key from environment in `plugin_api_backend.py`
- require Finnhub API key from environment in `finnhub_data_fetcher.py`
- document new `FINNHUB_API_KEY` and `TWELVE_DATA_API_KEY` variables in READMEs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6855afd9dd3c832ea1132022a7e86b66