### PR TITLE
Add JOURNAL_PATH override

### DIFF
--- a/_21.7.2_verify/NCOS_Voice_Journal_Documentation.md
+++ b/_21.7.2_verify/NCOS_Voice_Journal_Documentation.md
@@ -215,7 +215,7 @@ api:
   port: 8001
 
 journal:
-  path: "logs/trade_journal.jsonl"
+  path: "logs/trade_journal.jsonl"  # can be overridden with JOURNAL_PATH
   backup_path: "logs/backup/"
 
 voice:
@@ -279,7 +279,7 @@ def initialize_system():
         print(f"✓ Created directory: {dir_path}")
 
     # Create initial journal file
-    journal_path = Path("logs/trade_journal.jsonl")
+    journal_path = Path(os.environ.get("JOURNAL_PATH", "logs/trade_journal.jsonl"))
     if not journal_path.exists():
         journal_path.touch()
         print("✓ Created trade journal file")
@@ -463,13 +463,17 @@ Configure journal behavior in `system_config.yaml`:
 
 ```yaml
 journal:
-  path: "logs/trade_journal.jsonl"
+  path: "logs/trade_journal.jsonl"  # overridable via JOURNAL_PATH
   backup_enabled: true
   backup_interval: 3600  # seconds
   max_size_mb: 100
   rotation_enabled: true
   retention_days: 90
 ```
+
+You can also override the journal file location by setting the `JOURNAL_PATH`
+environment variable or by passing a custom path to `JournalManager` when
+initializing the API.
 
 ### ZBAR Integration Configuration
 
@@ -670,14 +674,14 @@ python ncos_zbar_api.py
 **Problem**: Dashboard shows "No entries found"  
 **Solution**:
 ```bash
-# Check journal file exists
-ls -la logs/trade_journal.jsonl
+# Check journal file exists (or path set via JOURNAL_PATH)
+ls -la ${JOURNAL_PATH:-logs/trade_journal.jsonl}
 
 # Create if missing
-touch logs/trade_journal.jsonl
+touch ${JOURNAL_PATH:-logs/trade_journal.jsonl}
 
 # Check permissions
-chmod 644 logs/trade_journal.jsonl
+chmod 644 ${JOURNAL_PATH:-logs/trade_journal.jsonl}
 ```
 
 #### 4. Streamlit Dashboard Errors
@@ -753,7 +757,7 @@ Always include:
 # Automated backup script
 #!/bin/bash
 BACKUP_DIR="logs/backup"
-JOURNAL="logs/trade_journal.jsonl"
+JOURNAL="${JOURNAL_PATH:-logs/trade_journal.jsonl}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
 cp $JOURNAL $BACKUP_DIR/journal_$TIMESTAMP.jsonl
@@ -893,7 +897,7 @@ For support or contributions, please refer to the project repository.
 🔧 Configuration Files:
 - config/system_config.yaml            → Main configuration
 - config/zbar_config.yaml              → ZBAR settings
-- logs/trade_journal.jsonl             → Journal storage
+ - logs/trade_journal.jsonl (overridable via JOURNAL_PATH)             → Journal storage
 ```
 
 ---

--- a/_21.7.2_verify/ZBAR_API_DEPLOYMENT.md
+++ b/_21.7.2_verify/ZBAR_API_DEPLOYMENT.md
@@ -48,7 +48,8 @@ Returns:
 To integrate with your existing NCOS system:
 
 1. Replace the `ZBARAgent.process_multi_timeframe()` method with calls to your actual `zbar_agent.py`
-2. Update the journal path to match your system configuration
+2. Configure the journal path using the `JOURNAL_PATH` environment variable or by
+   passing a custom path to `JournalManager`
 3. Add authentication if needed
 4. Deploy behind your NCOS API gateway
 

--- a/_21.7.2_verify/ncos_zbar_api.py
+++ b/_21.7.2_verify/ncos_zbar_api.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import List, Dict, Any, Optional
 from datetime import datetime
+import os
 import pandas as pd
 import json
 import uuid
@@ -112,7 +113,19 @@ class ZBARAgent:
 
 # --- Journal Manager ---
 class JournalManager:
-    def __init__(self, journal_path: str = "trade_journal.jsonl"):
+    def __init__(self, journal_path: Optional[str] = None):
+        """Manage trade journal entries.
+
+        Parameters
+        ----------
+        journal_path : str, optional
+            Path to the journal file. If not provided, the value from the
+            ``JOURNAL_PATH`` environment variable is used. If that is also not
+            set, ``"trade_journal.jsonl"`` is used by default.
+        """
+
+        if journal_path is None:
+            journal_path = os.environ.get("JOURNAL_PATH", "trade_journal.jsonl")
         self.journal_path = Path(journal_path)
 
     def log_entry(self, entry: JournalEntry):
@@ -139,6 +152,7 @@ class JournalManager:
 
 # Initialize components
 zbar_agent = ZBARAgent()
+# Journal path can be overridden via the JOURNAL_PATH environment variable
 journal_manager = JournalManager()
 
 # --- API Endpoints ---


### PR DESCRIPTION
## Summary
- allow journal path override via environment variable
- mention JOURNAL_PATH env var in docs and deployment guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6855afea38ec832eb7a25e216947fbfe