### PR TITLE
Add contribution logging and tests

### DIFF
--- a/risk_guardian_agent.py
+++ b/risk_guardian_agent.py
@@ -213,6 +213,10 @@ class RiskGuardianAgent:
                 if risk_type in risk_assessment:
                     contribution = risk_assessment[risk_type].get('risk_score', 0) * weight
                     contributions[risk_type] = contribution
+                    # Record each component's contribution to the overall risk score
+                    self.logger.info(
+                        f"{risk_type} contribution: {contribution:.2f}"
+                    )
                     self.logger.debug(
                         f"{risk_type} contribution: {contribution:.2f}",
                     )

--- a/tests/test_risk_guardian_logging.py
+++ b/tests/test_risk_guardian_logging.py
@@ -1,0 +1,32 @@
+import os
+import logging
+import types
+import sys
+
+# Provide dummy pandas and numpy for import
+sys.modules['pandas'] = types.ModuleType('pandas')
+sys.modules['numpy'] = types.ModuleType('numpy')
+
+from production_logging import configure_production_logging
+from risk_guardian_agent import RiskGuardianAgent
+
+
+def test_contribution_logging(tmp_path):
+    configure_production_logging(log_dir=str(tmp_path), log_level="INFO")
+    agent = RiskGuardianAgent({})
+    risk_assessment = {
+        'position_size_risk': {'risk_score': 100},
+        'exposure_risk': {'risk_score': 80},
+        'correlation_risk': {'risk_score': 0},
+        'drawdown_risk': {'risk_score': 0},
+        'daily_loss_risk': {'risk_score': 0},
+        'market_risk': {'risk_score': 0},
+    }
+    score = agent._calculate_overall_risk_score(risk_assessment)
+    assert score > 20
+    logging.shutdown()
+    log_path = os.path.join(str(tmp_path), "ncos_app.log")
+    assert os.path.exists(log_path)
+    with open(log_path) as f:
+        contents = f.read()
+    assert "position_size_risk contribution" in contents


### PR DESCRIPTION
## Summary
- log risk contribution at INFO level in `risk_guardian_agent`
- add unit test ensuring contribution logs are written when risk score is high

## Testing
- `pytest -q tests/test_risk_guardian_logging.py`
- `pytest -q` *(fails: ImportError in other tests)*

------
https://chatgpt.com/codex/tasks/task_b_6855b2478f54832ea1b4f3a5633ef526