### PR TITLE
Add voice tag parser tests

### DIFF
--- a/_21.7.2_verify/voice_tag_parser.py
+++ b/_21.7.2_verify/voice_tag_parser.py
@@ -60,6 +60,9 @@ class VoiceTagParser:
             "actions": ["mark", "log", "analyze", "scan", "check", "run", "execute", "monitor"]
         }
 
+        # Normalize patterns to lower case for matching
+        self.patterns = {k: [p.lower() for p in v] for k, v in self.patterns.items()}
+
         # Mapping for common aliases
         self.aliases = {
             "gold": "XAUUSD",
@@ -77,6 +80,9 @@ class VoiceTagParser:
             "short": "bearish",
             "ny": "new york"
         }
+
+        # Normalize alias keys for case-insensitive lookup
+        self.aliases = {k.lower(): v for k, v in self.aliases.items()}
 
         # Apply bias keywords from configuration
         bias_keywords = self.config.get("bias_keywords") or {}
@@ -119,11 +125,11 @@ class VoiceTagParser:
         # Direct pattern matching
         for symbol in self.patterns["symbols"]:
             if symbol in text:
-                # Apply alias mapping
+                # Apply alias mapping (symbols stored lower case)
                 return self.aliases.get(symbol, symbol.upper())
 
         # Regex for common forex pairs
-        forex_pattern = r"([A-Z]{3}[A-Z]{3}|[A-Z]{3}/[A-Z]{3})"
+        forex_pattern = r"\b([A-Z]{3}/?[A-Z]{3})\b"
         match = re.search(forex_pattern, text.upper())
         if match:
             return match.group(1).replace("/", "")

--- a/ncOS/voice_tag_parser.py
+++ b/ncOS/voice_tag_parser.py
@@ -60,6 +60,9 @@ class VoiceTagParser:
             "actions": ["mark", "log", "analyze", "scan", "check", "run", "execute", "monitor"]
         }
 
+        # Normalize patterns to lower case for matching
+        self.patterns = {k: [p.lower() for p in v] for k, v in self.patterns.items()}
+
         # Mapping for common aliases
         self.aliases = {
             "gold": "XAUUSD",
@@ -77,6 +80,9 @@ class VoiceTagParser:
             "short": "bearish",
             "ny": "new york"
         }
+
+        # Normalize alias keys for case-insensitive lookup
+        self.aliases = {k.lower(): v for k, v in self.aliases.items()}
 
         # Apply bias keywords from configuration
         bias_keywords = self.config.get("bias_keywords") or {}
@@ -119,11 +125,11 @@ class VoiceTagParser:
         # Direct pattern matching
         for symbol in self.patterns["symbols"]:
             if symbol in text:
-                # Apply alias mapping
+                # Apply alias mapping (symbols stored lower case)
                 return self.aliases.get(symbol, symbol.upper())
 
         # Regex for common forex pairs
-        forex_pattern = r"([A-Z]{3}[A-Z]{3}|[A-Z]{3}/[A-Z]{3})"
+        forex_pattern = r"\b([A-Z]{3}/?[A-Z]{3})\b"
         match = re.search(forex_pattern, text.upper())
         if match:
             return match.group(1).replace("/", "")

--- a/tests/test_voice_tag_parser.py
+++ b/tests/test_voice_tag_parser.py
@@ -1,0 +1,32 @@
+import unittest
+import importlib.util
+import sys
+import types
+
+class TestVoiceTagParser(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # stub spacy so the parser can be imported without the dependency
+        sys.modules['spacy'] = types.SimpleNamespace(load=lambda name: None)
+        spec = importlib.util.spec_from_file_location('voice_tag_parser', 'ncOS/voice_tag_parser.py')
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        cls.parser = module.VoiceTagParser()
+        cls.module = module
+
+    def test_entity_extraction_from_docs_example(self):
+        tag = self.parser.parse("mark gold bullish on H4")
+        self.assertEqual(tag.symbol, "XAUUSD")
+        self.assertEqual(tag.timeframe, "H4")
+        self.assertEqual(tag.bias, "bullish")
+        self.assertEqual(tag.action, "mark")
+
+    def test_menu_action_generation(self):
+        tag = self.parser.parse("mark gold bullish on H4")
+        action = self.parser.to_menu_action(tag)
+        self.assertEqual(action["action"], "append_journal")
+        self.assertEqual(action["params"]["symbol"], "XAUUSD")
+        self.assertEqual(action["params"]["timeframe"], "H4")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for voice tag parser covering doc example
- normalize patterns and aliases for case-insensitive matching
- update regex for forex pair extraction

## Testing
- `pytest -q tests/test_voice_tag_parser.py`

------
https://chatgpt.com/codex/tasks/task_b_6855b2778f40832ebf087b32b652d62d