### PR TITLE
Improve test setup instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: setup-dev test
+
+# Install runtime and development dependencies
+setup-dev:
+	pip install -r requirements.txt
+	pip install -r requirements-dev.txt
+	python -m spacy download en_core_web_sm
+
+# Run the test suite using pytest
+# Assumes dependencies have been installed
+
+
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -41,15 +41,18 @@ quotes from Finnhub or Twelve Data.
 
 ## Running Tests
 
-Install the project dependencies before executing the test suite. The tests rely
-on `pandas`, `numpy` and all other packages listed in `requirements.txt`:
+Before executing any tests you **must** install the runtime dependencies listed
+in `requirements.txt`. Many of the tests depend on packages such as `pandas` and
+`numpy` and will fail if they are missing.
 
 ```bash
 pip install -r requirements.txt
 python -m spacy download en_core_web_sm
 ```
 
-For additional test utilities install the development requirements as well:
+For additional utilities (like coverage tools) install the development
+requirements as well. You can do this manually or run `make setup-dev` if `make`
+is available:
 
 ```bash
 pip install -r requirements-dev.txt


### PR DESCRIPTION
## Summary
- emphasize installing dependencies before running the tests
- add `Makefile` with `setup-dev` and `test` helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails to build wheel)*

------
https://chatgpt.com/codex/tasks/task_b_6855b3c65eb0832e8243ecd7ee24766a