### PR TITLE
Fix voice journal docs script path

### DIFF
--- a/_21.7.2_verify/VOICE_INTEGRATION_INSTRUCTIONS.md
+++ b/_21.7.2_verify/VOICE_INTEGRATION_INSTRUCTIONS.md
@@ -118,5 +118,5 @@ python zbar_voice_integration.py
 python menu_voice_integration.py
 
 # Test unified system
-python ncos_voice_unified.py
+python core/ncos_voice_unified.py
 ```

--- a/docs/QUICK_START_Voice_Journal_v21.7.2.md
+++ b/docs/QUICK_START_Voice_Journal_v21.7.2.md
@@ -29,7 +29,7 @@ python api/main.py
 streamlit run dashboard/voice_command_dashboard.py
 
 # Terminal 3: Voice Interface
-python ncos_voice/ncos_voice_unified.py
+python core/ncos_voice_unified.py
 ```
 
 ## 🎤 First Commands


### PR DESCRIPTION
## Summary
- reference `core/ncos_voice_unified.py` in the voice journal quick start
- adjust VOICE_INTEGRATION_INSTRUCTIONS with same path

## Testing
- `pytest tests/test_voice_menu_system.py -q`
- `pytest tests/test_chart_engine.py -q`
- `pytest tests/test_add_structure.py -q` *(fails: confirmation logic)*

------
https://chatgpt.com/codex/tasks/task_b_6855b37c12d0832eb8a72e21fa1f8647