### PR TITLE
Fix duplicate import in plugin API backend

### DIFF
--- a/ncos_plugin/plugin_api_backend.py
+++ b/ncos_plugin/plugin_api_backend.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import json
 import os
 import requests
-from fastapi import Query
 
 # Import your custom Finnhub client
 from ncos_plugin.finnhub_data_fetcher import finnhub_client


### PR DESCRIPTION
## Summary
- remove redundant `Query` import from plugin_api_backend

## Testing
- `flake8 ncos_plugin/plugin_api_backend.py`

------
https://chatgpt.com/codex/tasks/task_b_6855b3f43248832e9dab764236d8ef8e