### PR TITLE
Add tests for voice parsing and menu integration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_menu_voice.py
+++ b/tests/test_menu_voice.py
@@ -1,0 +1,48 @@
+import sys
+from unittest.mock import MagicMock, patch
+import unittest
+
+# Stub dependencies not available in the test environment
+sys.modules['spacy'] = MagicMock()
+sys.modules['yaml'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+
+sys.path.append('_21.7.2_verify')
+from menu_voice_integration import VoiceEnabledMenuSystem
+
+
+class DummyMenu(VoiceEnabledMenuSystem):
+    def _add_voice_menu(self):
+        # avoid calling get_main_menu during tests
+        pass
+
+
+class TestVoiceMenuSystem(unittest.TestCase):
+    def setUp(self):
+        self.menu = DummyMenu(orchestrator=None, config={"api_base": "http://api"})
+        self.menu.update_context = MagicMock()
+
+    def test_voice_mark_setup_posts_journal(self):
+        # Simulate user inputs for command, confirmation and analysis prompt
+        inputs = iter([
+            "Mark gold bullish on 4hour swept lows at 2358",
+            "y",
+            "n",
+        ])
+        with patch("builtins.input", lambda *_: next(inputs)):
+            with patch("requests.post") as mock_post:
+                mock_post.return_value.status_code = 200
+                result = self.menu._voice_mark_setup()
+
+        self.assertEqual(result["status"], "success")
+
+        mock_post.assert_called()
+        sent_payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(sent_payload["symbol"], "XAUUSD")
+        self.assertEqual(sent_payload["timeframe"], "H4")
+        self.assertEqual(sent_payload["bias"], "bullish")
+        self.assertEqual(sent_payload["notes"], "swept lows 2358")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_voice_parser.py
+++ b/tests/test_voice_parser.py
@@ -1,0 +1,29 @@
+import sys
+from unittest.mock import MagicMock
+import unittest
+
+# Ensure parser module can be imported without heavy dependencies
+sys.modules['spacy'] = MagicMock()
+sys.path.append('_21.7.2_verify')
+import voice_tag_parser
+
+class TestVoiceTagParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = voice_tag_parser.VoiceTagParser()
+
+    def test_mark_phrase_parsing(self):
+        tag = self.parser.parse('Mark gold bullish on 4hour swept lows at 2358')
+        self.assertEqual(tag.symbol, 'XAUUSD')
+        self.assertEqual(tag.timeframe, 'H4')
+        self.assertEqual(tag.bias, 'bullish')
+        self.assertEqual(tag.notes, 'swept lows 2358')
+
+    def test_log_phrase_parsing(self):
+        tag = self.parser.parse('Log euro bearish 1min after NFP')
+        self.assertEqual(tag.symbol, 'EURUSD')
+        self.assertEqual(tag.timeframe, 'M1')
+        self.assertEqual(tag.bias, 'bearish')
+        self.assertEqual(tag.notes, 'after nfp')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add pytest config
- test VoiceTagParser parsing of sample voice phrases
- test VoiceEnabledMenuSystem interacts with journal API

## Testing
- `pytest tests/test_voice_parser.py tests/test_menu_voice.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6855b1df0188832e954510562ef7a6a2