### PR TITLE
Add missing speechrecognition dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.31.0
 python-dateutil==2.8.2
 numpy==1.24.3
 python-multipart==0.0.6
+speechrecognition


### PR DESCRIPTION
## Summary
- ensure voice features work by adding `speechrecognition` to `requirements.txt`

## Testing
- `pip install numpy==1.26.4`
- `pip install pandas==2.1.3`
- `pip install fastapi==0.104.1 uvicorn==0.24.0 streamlit==1.28.1 pydantic==2.5.0 PyYAML==6.0.1 requests==2.31.0 python-dateutil==2.9.0.post0 python-multipart==0.0.6 speechrecognition`
- `pip install matplotlib`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'engine')*

------
https://chatgpt.com/codex/tasks/task_b_6855c584b648832e9e4e24b4b77a80b7