### PR TITLE
Add config loader and env docs

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -5,14 +5,17 @@ ncOS Journal Dashboard - Phoenix Edition
 import streamlit as st
 import pandas as pd
 import json
+import os
 import requests
 from datetime import datetime, timedelta
 import plotly.express as px
 import plotly.graph_objects as go
 from typing import List, Dict, Any
+from production.production_config import load_production_config
 
 # Configuration
-API_URL = "http://localhost:8001"
+CONFIG = load_production_config(os.environ.get("NCOS_CONFIG_PATH"))
+API_URL = CONFIG.api.dashboard
 
 # Page config
 st.set_page_config(

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,22 @@
+# Required Environment Variables
+
+The NCOS system relies on several environment variables to configure runtime behavior.
+If a variable is not provided, the default value from `production/production_config.py` will be used.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FINNHUB_API_KEY` | *(none)* | API key for market data integration |
+| `TWELVE_DATA_API_KEY` | *(none)* | API key for alternative market data |
+| `NCOS_ENVIRONMENT` | `production` | Deployment environment name |
+| `NCOS_LOG_LEVEL` | `INFO` | Logging verbosity |
+| `NCOS_LOG_DIR` | `/var/log/ncos` | Directory for application logs |
+| `NCOS_MONITORING_PORT` | `9090` | Port for the monitoring service |
+| `NCOS_CIRCUIT_BREAKER_ENABLED` | `true` | Enable circuit breaker logic |
+| `NCOS_JOURNAL_API_URL` | `http://localhost:8000` | Journal API endpoint |
+| `NCOS_DASHBOARD_API_URL` | `http://localhost:8001` | Dashboard API endpoint |
+| `NCOS_LLM_API_URL` | `http://localhost:8002` | LLM assistant endpoint |
+| `NCOS_CONFIG_PATH` | *(none)* | Optional path to a YAML configuration file |
+
+All of these variables can also be provided in a YAML file loaded via
+`load_production_config`. Environment variables take precedence over values
+in the configuration file.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ NCOS (Neural Computation Operating System) v21 is a production-ready financial d
 - Comprehensive risk management
 
 ## Environment Variables
-Ensure the following variables are set before starting the system:
+See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for the full list of
+supported variables and defaults. At a minimum you should provide API keys:
 ```
 export FINNHUB_API_KEY="<your-finnhub-key>"
 export TWELVE_DATA_API_KEY="<your-twelvedata-key>"

--- a/enhanced_conflict_detector.py
+++ b/enhanced_conflict_detector.py
@@ -4,16 +4,19 @@ Identifies and logs potential conflicts between active trades and new setups
 """
 
 import logging
+import os
 from datetime import datetime
 from typing import Dict, Any, Optional, List
 from pydantic import BaseModel
 import json
 import requests
+from production.production_config import load_production_config
 
 logger = logging.getLogger(__name__)
 
 # Journal API endpoint
-JOURNAL_API = "http://localhost:8000"
+CONFIG = load_production_config(os.environ.get("NCOS_CONFIG_PATH"))
+JOURNAL_API = CONFIG.api.journal
 
 class ConflictDetectionConfig(BaseModel):
     """Configuration for conflict detection"""

--- a/enhanced_trade_narrative_llm.py
+++ b/enhanced_trade_narrative_llm.py
@@ -5,14 +5,17 @@ Generates comprehensive trade narratives and insights
 
 import json
 import logging
+import os
 from datetime import datetime
 from typing import Dict, Any, List, Optional
 import requests
+from production.production_config import load_production_config
 
 logger = logging.getLogger(__name__)
 
 # Journal API endpoint
-JOURNAL_API = "http://localhost:8000"
+CONFIG = load_production_config(os.environ.get("NCOS_CONFIG_PATH"))
+JOURNAL_API = CONFIG.api.journal
 
 class EnhancedTradeNarrativeLLM:
     """Enhanced narrative generator with journal integration"""

--- a/enhanced_xanflow_orchestrator.py
+++ b/enhanced_xanflow_orchestrator.py
@@ -4,6 +4,7 @@ Manages ISPTS pipeline execution with comprehensive logging
 """
 
 import logging
+import os
 import queue
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -12,11 +13,13 @@ from typing import Dict, Any, List, Optional
 import json
 import requests
 from dataclasses import dataclass
+from production.production_config import load_production_config
 
 logger = logging.getLogger(__name__)
 
 # Journal API endpoint
-JOURNAL_API = "http://localhost:8000"
+CONFIG = load_production_config(os.environ.get("NCOS_CONFIG_PATH"))
+JOURNAL_API = CONFIG.api.journal
 
 @dataclass
 class PipelineStage:

--- a/llm_assistant.py
+++ b/llm_assistant.py
@@ -11,6 +11,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
+from production.production_config import load_production_config
 from pathlib import Path
 
 import uvicorn
@@ -28,6 +29,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Configuration
+config = load_production_config(os.environ.get("NCOS_CONFIG_PATH"))
 @dataclass
 class LLMConfig:
     """LLM Assistant Configuration"""
@@ -36,7 +38,7 @@ class LLMConfig:
     temperature: float = 0.7
     max_tokens: int = 2000
     system_prompt_file: str = "llm_system_prompt.txt"
-    journal_api_url: str = "http://localhost:8000"
+    journal_api_url: str = config.api.journal
     
     def load_system_prompt(self) -> str:
         """Load system prompt from file"""

--- a/llm_dashboard_integration.py
+++ b/llm_dashboard_integration.py
@@ -4,14 +4,18 @@ import requests
 import asyncio
 import websockets
 import json
+import os
 from datetime import datetime
+from production.production_config import load_production_config
+
+config = load_production_config(os.environ.get("NCOS_CONFIG_PATH"))
 
 class LLMIntegration:
     """Integration with ncOS LLM Assistant"""
-    
-    def __init__(self, llm_url="http://localhost:8002"):
-        self.llm_url = llm_url
-        self.ws_url = llm_url.replace("http", "ws") + "/ws"
+
+    def __init__(self, llm_url: str | None = None):
+        self.llm_url = llm_url or config.api.llm
+        self.ws_url = self.llm_url.replace("http", "ws") + "/ws"
         
     def chat(self, message: str, include_context: bool = True) -> dict:
         """Send message to LLM assistant"""

--- a/ncos_journal/dashboard/app.py
+++ b/ncos_journal/dashboard/app.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import plotly.express as px
 import plotly.graph_objects as go
 from pathlib import Path
+from production.production_config import load_production_config
 
 # Page config
 st.set_page_config(
@@ -16,7 +17,8 @@ st.set_page_config(
 )
 
 # API endpoints
-API_URL = "http://localhost:8000"
+CONFIG = load_production_config(os.environ.get("NCOS_CONFIG_PATH"))
+API_URL = CONFIG.api.journal
 ZBAR_LOG_FILE = "/mnt/data/logs/trade_journal.jsonl"
 LOCAL_LOG_FILE = "data/journals/trade_journal.jsonl"
 

--- a/production/production_config.py
+++ b/production/production_config.py
@@ -37,6 +37,12 @@ class AgentConfig(BaseModel):
     max_retries: int = Field(default=3, ge=0, le=10)
     memory_limit_mb: Optional[int] = Field(default=None, ge=100, le=10000)
 
+class APIConfig(BaseModel):
+    """External service endpoints"""
+    journal: str = Field(default="http://localhost:8000")
+    dashboard: str = Field(default="http://localhost:8001")
+    llm: str = Field(default="http://localhost:8002")
+
 class ProductionConfig(BaseModel):
     """Main production configuration"""
     environment: str = Field(default="production", pattern="^(development|staging|production)$")
@@ -45,6 +51,7 @@ class ProductionConfig(BaseModel):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig)
     monitoring: MonitoringConfig = Field(default_factory=MonitoringConfig)
+    api: APIConfig = Field(default_factory=APIConfig)
     agents: Dict[str, AgentConfig] = Field(default_factory=dict)
 
     # Feature flags
@@ -84,7 +91,10 @@ def load_production_config(config_path: Optional[str] = None) -> ProductionConfi
         "NCOS_LOG_LEVEL": "logging.level",
         "NCOS_LOG_DIR": "logging.directory",
         "NCOS_MONITORING_PORT": "monitoring.port",
-        "NCOS_CIRCUIT_BREAKER_ENABLED": "features.circuit_breakers"
+        "NCOS_CIRCUIT_BREAKER_ENABLED": "features.circuit_breakers",
+        "NCOS_JOURNAL_API_URL": "api.journal",
+        "NCOS_DASHBOARD_API_URL": "api.dashboard",
+        "NCOS_LLM_API_URL": "api.llm",
     }
 
     for env_var, config_path in env_mappings.items():
@@ -133,6 +143,11 @@ monitoring:
   port: 9090
   retention_minutes: 60
   collection_interval: 10
+
+api:
+  journal: http://localhost:8000
+  dashboard: http://localhost:8001
+  llm: http://localhost:8002
 
 # Agent-specific configurations
 agents:


### PR DESCRIPTION
## Summary
- expose API endpoints via `production_config` loader
- load configuration in dashboard and service modules
- document all environment variables in `ENVIRONMENT_VARIABLES.md`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_b_68567cb83e58832e8f6ecff376b9e78f