### PR TITLE
Add basic backtesting engine

### DIFF
--- a/backtesting/engine.py
+++ b/backtesting/engine.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from typing import Any, Dict, Iterable, List, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+class BacktestEngine:
+    """Simple backtesting engine for NCOS strategies."""
+
+    def __init__(self, strategies: Sequence[Any], initial_capital: float = 10000.0) -> None:
+        self.strategies = list(strategies)
+        self.initial_capital = initial_capital
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset engine state."""
+        self.cash = self.initial_capital
+        self.position = 0.0
+        self.trades: List[Dict[str, Any]] = []
+        self.equity: List[float] = []
+
+    @staticmethod
+    def load_csv(path: str) -> pd.DataFrame:
+        """Load historical data from CSV.
+
+        The CSV must contain a ``close`` column and use the first column as the
+        datetime index.
+        """
+        df = pd.read_csv(path, parse_dates=True, index_col=0)
+        if "close" not in df.columns:
+            raise ValueError("CSV must contain a 'close' column")
+        return df
+
+    def run(self, data: pd.DataFrame, symbol: str = "TEST") -> Dict[str, float]:
+        """Run backtest on provided data."""
+        self.reset()
+        total = len(data)
+        for i, (timestamp, row) in enumerate(data.iterrows()):
+            market_data = {
+                "prices": data.loc[:timestamp, "close"].tolist(),
+                "current_price": row["close"],
+                "symbol": symbol,
+                "index": i,
+                "last_index": total - 1,
+            }
+            for strat in self.strategies:
+                if hasattr(strat, "generate_signals"):
+                    signals = strat.generate_signals(market_data)
+                    for sig in signals:
+                        self._execute_signal(sig, row["close"], timestamp)
+            self.equity.append(self.cash + self.position * row["close"])
+        return self._compute_metrics()
+
+    def _execute_signal(self, signal: Dict[str, Any], price: float, timestamp: Any) -> None:
+        action = signal.get("type") or signal.get("action")
+        if action in {"buy", "long", "entry_long"} and self.position == 0:
+            qty = self.cash / price
+            self.position = qty
+            self.cash -= qty * price
+            self.trades.append({"entry_time": str(timestamp), "entry_price": price})
+        elif action in {"sell", "short", "exit_long"} and self.position > 0:
+            pnl = (price - self.trades[-1]["entry_price"]) * self.position
+            self.cash += self.position * price
+            self.position = 0
+            self.trades[-1].update(
+                {"exit_time": str(timestamp), "exit_price": price, "pnl": pnl}
+            )
+
+    def _compute_metrics(self) -> Dict[str, float]:
+        eq = np.array(self.equity, dtype=float)
+        if len(eq) < 2:
+            returns = np.array([])
+        else:
+            returns = np.diff(eq) / eq[:-1]
+        sharpe = (
+            float(np.mean(returns) / np.std(returns) * np.sqrt(252))
+            if len(returns) > 1 and np.std(returns) > 0
+            else 0.0
+        )
+        running_max = np.maximum.accumulate(eq) if len(eq) else np.array([])
+        drawdowns = (eq - running_max) / running_max if len(eq) else np.array([])
+        max_drawdown = float(drawdowns.min()) if len(drawdowns) else 0.0
+        profits = [t["pnl"] for t in self.trades if t.get("pnl", 0) > 0]
+        losses = [-t["pnl"] for t in self.trades if t.get("pnl", 0) < 0]
+        if losses:
+            profit_factor = float(sum(profits) / sum(losses)) if profits else 0.0
+        else:
+            profit_factor = float("inf") if profits else 0.0
+        return {
+            "sharpe_ratio": sharpe,
+            "max_drawdown": max_drawdown,
+            "profit_factor": profit_factor,
+        }
+
+    def save_results(self, result_path: str, trades_path: str) -> None:
+        """Save metrics and trade log."""
+        metrics = self._compute_metrics()
+        with open(result_path, "w", encoding="utf-8") as f:
+            json.dump(metrics, f, indent=2)
+        if self.trades:
+            with open(trades_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=list(self.trades[0].keys()))
+                writer.writeheader()
+                writer.writerows(self.trades)
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="NCOS backtesting engine")
+    parser.add_argument("data", help="CSV file with historical price data")
+    parser.add_argument(
+        "--strategy",
+        choices=["maz2", "tmc"],
+        default="maz2",
+        help="Strategy to run",
+    )
+    parser.add_argument("--output_json", default="backtest_results.json")
+    parser.add_argument("--output_csv", default="trades.csv")
+    args = parser.parse_args()
+
+    df = BacktestEngine.load_csv(args.data)
+    if args.strategy == "tmc":
+        from agents.tmc_executor import TMCExecutor
+
+        strategy = TMCExecutor({})
+    else:
+        from agents.maz2_executor import MAZ2Executor
+
+        strategy = MAZ2Executor({})
+
+    engine = BacktestEngine([strategy])
+    metrics = engine.run(df)
+    engine.save_results(args.output_json, args.output_csv)
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/docs/PREDICTIVE_ENGINE_COMPLETE.json
+++ b/docs/PREDICTIVE_ENGINE_COMPLETE.json
@@ -26,7 +26,7 @@
       "phase": 3,
       "name": "Testing & Validation",
       "components": [
-        "predictive_backtest.py",
+        "backtesting/engine.py",
         "grade_analysis_dashboard.py",
         "validate_predictive.py"
       ]
@@ -46,7 +46,7 @@
     "ncos_feature_extractor.py",
     "ncos_data_enricher.py",
     "ncos_divergence_strategy_agent.py",
-    "predictive_backtest.py",
+    "backtesting/engine.py",
     "grade_analysis_dashboard.py",
     "validate_predictive.py",
     "test_predictive_engine.py",

--- a/docs/PREDICTIVE_ENGINE_GUIDE.md
+++ b/docs/PREDICTIVE_ENGINE_GUIDE.md
@@ -126,9 +126,9 @@ Ensures all components are properly installed and configured.
 
 ### 2. Backtest Analysis
 ```bash
-python predictive_backtest.py
+python -m backtesting.engine data/price_data.csv
 ```
-Runs comprehensive comparison of performance with/without predictive filtering.
+Runs a sample backtest using the new engine.
 
 ### 3. Results Visualization
 ```bash

--- a/scripts/quick_start_predictive.py
+++ b/scripts/quick_start_predictive.py
@@ -51,22 +51,21 @@ def main():
 
     if response.lower() == 'y':
         if run_command(
-            "python predictive_backtest.py",
+            "python -m backtesting.engine data/price_data.csv",
             "Step 2: Running Backtest Analysis"
         ):
             print("\n✅ Backtest complete!")
             print("\n📁 Generated files:")
-            print("  - predictive_backtest_results.json")
-            print("  - predictive_trades_log.csv")
-            print("  - predictive_backtest_analysis.png")
+            print("  - backtest_results.json")
+            print("  - trades.csv")
 
     # Step 3: Next steps
     print("\n" + "="*60)
     print("🎯 NEXT STEPS")
     print("="*60)
     print("\n1. Review Results:")
-    print("   - Check predictive_backtest_results.json for metrics")
-    print("   - View predictive_backtest_analysis.png for charts")
+    print("   - Check backtest_results.json for metrics")
+    print("   - Inspect trades.csv for executed trades")
 
     print("\n2. Launch Dashboard (requires streamlit):")
     print("   streamlit run grade_analysis_dashboard.py")

--- a/tests/test_backtesting_engine.py
+++ b/tests/test_backtesting_engine.py
@@ -1,0 +1,51 @@
+import unittest
+import pandas as pd
+
+from backtesting.engine import BacktestEngine
+
+
+class BuyHoldStrategy:
+    """Buy at first bar and sell at last bar."""
+
+    def generate_signals(self, data):
+        if data["index"] == 0:
+            return [{"action": "buy"}]
+        if data["index"] == data["last_index"]:
+            return [{"action": "sell"}]
+        return []
+
+
+class NoTradeStrategy:
+    def generate_signals(self, data):
+        return []
+
+
+class TestBacktestEngine(unittest.TestCase):
+    def setUp(self):
+        prices = [100, 101, 102, 103]
+        dates = pd.date_range("2024-01-01", periods=4, freq="D")
+        self.df = pd.DataFrame({"close": prices}, index=dates)
+
+    def test_basic_backtest(self):
+        engine = BacktestEngine([BuyHoldStrategy()], initial_capital=1000)
+        metrics = engine.run(self.df)
+        self.assertEqual(len(engine.trades), 1)
+        self.assertAlmostEqual(engine.trades[0]["pnl"], 30.0, places=2)
+        self.assertGreater(metrics["profit_factor"], 1)
+
+    def test_no_trades(self):
+        engine = BacktestEngine([NoTradeStrategy()], initial_capital=1000)
+        metrics = engine.run(self.df)
+        self.assertEqual(len(engine.trades), 0)
+        self.assertEqual(metrics["profit_factor"], 0)
+        self.assertEqual(metrics["sharpe_ratio"], 0)
+
+    def test_constant_prices_sharpe(self):
+        df = pd.DataFrame({"close": [100, 100, 100]}, index=pd.date_range("2024", periods=3))
+        engine = BacktestEngine([BuyHoldStrategy()], initial_capital=1000)
+        metrics = engine.run(df)
+        self.assertEqual(metrics["sharpe_ratio"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create simple backtesting engine with Sharpe, drawdown, and profit factor metrics
- store trade logs to CSV and metrics to JSON
- reference engine from quick start script and documentation
- add unit tests for engine

## Testing
- `pip install -q -r requirements.txt`
- `pip install pytest -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68567e5c69a4832e905b381b3745eb55