### PR TITLE
Add missing predictive engine config sections

### DIFF
--- a/config/predictive_engine_config.yaml
+++ b/config/predictive_engine_config.yaml
@@ -13,3 +13,33 @@ predictive_scorer:
     A: 0.85  # Top tier setups
     B: 0.70  # Quality setups
     C: 0.55  # Marginal setups
+
+  # Additional predictive scorer settings
+  min_score_to_emit_potential_entry: 0.65
+  conflict_detection_settings:
+    enabled: true
+    min_new_setup_maturity_for_conflict_alert: 0.70
+    suggest_review_trade_if_new_setup_maturity_above: 0.80
+
+data_enricher:
+  enabled: true
+  calculate_tick_density: true
+  calculate_spread_stability: true
+  calculate_htf_alignment: true
+  spread_tracker_config:
+    enabled: true
+    window_size: 25
+    high_vol_baseline: 0.0008
+    stability_threshold: 0.3
+
+feature_extractor:
+  enabled: true
+  use_cached_features: true
+  feature_cache_ttl_seconds: 300
+
+journaling:
+  enabled: true
+  log_all_evaluations: false
+  min_maturity_score_to_log: 0.60
+  log_format: json
+  log_directory: logs/predictive_journal


### PR DESCRIPTION
## Summary
- extend `config/predictive_engine_config.yaml` with journaling, data enrichment and feature extractor settings
- validate predictive engine configuration with pydantic schema

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'memory_manager')*
- `python3 - <<'PY'
import yaml
from ncos_predictive_schemas import PredictiveEngineConfig
with open('config/predictive_engine_config.yaml') as f:
    data = yaml.safe_load(f)
config = PredictiveEngineConfig(**data)
print('Validation successful')
print(config.data_enricher)
PY`

------
https://chatgpt.com/codex/tasks/task_b_6856a3f31304832e9072ffd7171ce498