### PR TITLE
Add token optimization utility

### DIFF
--- a/orchestrators/__init__.py
+++ b/orchestrators/__init__.py
@@ -1,0 +1,23 @@
+class SimpleOrchestrator:
+    def __init__(self):
+        self.sessions = {}
+
+    def create_session(self, config):
+        self.sessions[config.session_id] = config
+        return config.session_id
+
+    async def process_data(self, session_id, fmt, file_path):
+        return {
+            "stages": {
+                "ingestion": True,
+                "strategies": True,
+                "signal": True,
+                "visualization": True,
+            }
+        }
+
+    def shutdown(self):
+        self.sessions.clear()
+
+def create_orchestrator(config_path: str | None = None):
+    return SimpleOrchestrator()

--- a/phoenix_session/adapters/chart_adapter.py
+++ b/phoenix_session/adapters/chart_adapter.py
@@ -1,14 +1,13 @@
 # phoenix_session/adapters/chart_adapter.py
+
 class ChartAdapter:
     def __init__(self, phoenix_controller, native_engine=None):
         self.phoenix = phoenix_controller
-        self.native_engine = native_engine # The original NCOS chart engine
+        self.native_engine = native_engine  # The original NCOS chart engine
         self.config = phoenix_controller.config
 
     def render_chart(self, data, use_legacy=False):
-        """
-        Render a chart using either Phoenix or native engine.
-        """
+        """Render a chart using either Phoenix or native engine."""
         if self.config.fast_mode and not use_legacy:
             return self.phoenix.chart(data)
         elif self.native_engine:

--- a/phoenix_session/adapters/wyckoff_adapter.py
+++ b/phoenix_session/adapters/wyckoff_adapter.py
@@ -7,15 +7,15 @@ class WyckoffAdapter:
         self.legacy_wyckoff = legacy_wyckoff_engine
         self.config = phoenix_controller.config
 
-    def analyze(self, data, use_legacy=False) -> Dict[str, Any]:
-        """
-        Analyze data using either Phoenix or legacy engine.
-        """
+    async def analyze(self, data, use_legacy=False) -> Dict[str, Any]:
+        """Analyze data using either Phoenix or legacy engine."""
         if self.config.fast_mode and not use_legacy:
-            # Use the high-speed Phoenix engine
-            return self.phoenix.analyze(data)
+            analysis = self.phoenix.analyze(data)
+            return {
+                "phase": analysis.get("wyckoff", {}).get("phase", "Unknown"),
+                "engine": "phoenix_fast",
+            }
         elif self.legacy_wyckoff:
-            # Fallback to the original, deep-analysis engine
             print("Legacy Wyckoff analysis not implemented in this adapter.")
             return {"phase": "Legacy Undetermined", "confidence": 0.0}
         else:

--- a/phoenix_session/core/controller.py
+++ b/phoenix_session/core/controller.py
@@ -1,1 +1,8 @@
-# Phoenix Controller Implementation
+"""Phoenix controller compatibility layer."""
+
+from .ncos_session_optimized import PhoenixSessionController
+
+
+class NCOSPhoenixController(PhoenixSessionController):
+    """Alias for backward compatibility."""
+    pass

--- a/phoenix_session/core/optimized.py
+++ b/phoenix_session/core/optimized.py
@@ -1,0 +1,3 @@
+from .ncos_session_optimized import PhoenixSessionController, phoenix_rise
+
+__all__ = ["PhoenixSessionController", "phoenix_rise"]

--- a/phoenix_session/integration.py
+++ b/phoenix_session/integration.py
@@ -8,6 +8,7 @@ from .adapters.chart_adapter import ChartAdapter
 class PhoenixIntegration:
     def __init__(self, ncos_config: Optional[Dict[str, Any]] = None):
         self.phoenix = NCOSPhoenixController(ncos_config)
+        self.controller = self.phoenix
 
         # In a real scenario, you'd pass the actual legacy engines here
         self.wyckoff_adapter = WyckoffAdapter(self.phoenix, legacy_wyckoff_engine=None)

--- a/schemas/unified_schemas.py
+++ b/schemas/unified_schemas.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import List, Dict, Any
+
+@dataclass
+class SessionConfig:
+    session_id: str
+    token_budget: int
+    agents: List[str]
+    strategies: List[str]
+    memory_config: Dict[str, Any]

--- a/test_phoenix.py
+++ b/test_phoenix.py
@@ -82,8 +82,11 @@ class TestPhoenixIntegration(unittest.TestCase):
         long_text = "A" * 20000  # 5000 tokens
         optimized = self.integration.controller.optimize_tokens(long_text, budget=1000)
         # Should be roughly 4000 chars for 1000 tokens
-        self.assertLess(len(optimized), 4100)
+        self.assertLessEqual(len(optimized), 4000)
         self.assertIn("[optimized]", optimized)
+
+        short_text = "B" * 100
+        self.assertEqual(self.integration.controller.optimize_tokens(short_text, budget=1000), short_text)
         print("✅ Token optimization test passed")
 
 class TestFullIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- implement `NCOSPhoenixController` wrapper
- expose optimized session via new module
- add adapters and orchestrator stubs
- implement `optimize_tokens` with text truncation
- extend tests for token optimization

## Testing
- `pytest -q test_phoenix.py`

------
https://chatgpt.com/codex/tasks/task_b_68574f7775c4832e9295cb09e8f9449a