### PR TITLE
Add functional Phoenix controller with adapter registry

### DIFF
--- a/phoenix_session/core/controller.py
+++ b/phoenix_session/core/controller.py
@@ -1,8 +1,80 @@
-"""Phoenix controller compatibility layer."""
+"""Phoenix controller used by :class:`PhoenixIntegration`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional
 
 from .ncos_session_optimized import PhoenixSessionController
 
 
-class NCOSPhoenixController(PhoenixSessionController):
-    """Alias for backward compatibility."""
-    pass
+class NCOSPhoenixController:
+    """Lightweight controller that wraps :class:`PhoenixSessionController`.
+
+    This layer keeps a small registry of adapters and exposes a subset of the
+    methods that ``PhoenixIntegration`` relies on.  It delegates the heavy work
+    to :class:`PhoenixSessionController` but adds a thin compatibility API for
+    adapter management and status reporting.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        # Underlying optimized controller with all core functionality
+        self._controller = PhoenixSessionController(config)
+        # Local registry of connected adapters
+        self._adapters: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Basic proxy attributes
+    # ------------------------------------------------------------------
+    @property
+    def config(self):
+        """Expose the underlying configuration."""
+        return self._controller.config
+
+    # ------------------------------------------------------------------
+    # Adapter management
+    # ------------------------------------------------------------------
+    def connect_adapter(self, name: str, adapter: Any) -> None:
+        """Register an adapter for later use."""
+        self._adapters[name] = adapter
+
+    # ``register_adapter`` is an alias used in some legacy code
+    register_adapter = connect_adapter
+
+    def get_registered_adapters(self) -> Iterable[str]:
+        """Return an iterable of registered adapter names."""
+        return self._adapters.keys()
+
+    # ------------------------------------------------------------------
+    # Delegated methods from ``PhoenixSessionController``
+    # ------------------------------------------------------------------
+    def analyze(self, data: Any = None) -> Dict[str, Any]:
+        return self._controller.analyze(data)
+
+    def chart(self, data: Any = None, chart_type: Optional[str] = None) -> str:
+        return self._controller.chart(data, chart_type)
+
+    def quick_start(self, data_path: Optional[str] = None) -> Dict[str, Any]:
+        return self._controller.quick_start(data_path)
+
+    def get_performance_stats(self) -> Dict[str, Any]:
+        return self._controller.get_performance_stats()
+
+    def optimize_tokens(self, text: str, budget: int) -> str:
+        return self._controller.optimize_tokens(text, budget)
+
+    def shutdown(self) -> None:
+        self._controller.shutdown()
+
+    # ------------------------------------------------------------------
+    # Enhanced status reporting
+    # ------------------------------------------------------------------
+    def get_status(self) -> Dict[str, Any]:
+        """Return status information including adapter registry."""
+        status = self._controller.get_status()
+        status["adapters"] = list(self.get_registered_adapters())
+        return status
+
+
+# Backwards compatibility export
+PhoenixController = NCOSPhoenixController
+

--- a/test_phoenix.py
+++ b/test_phoenix.py
@@ -41,6 +41,10 @@ class TestPhoenixIntegration(unittest.TestCase):
         self.assertIsNotNone(self.integration)
         self.assertIsNotNone(self.integration.controller)
         self.assertTrue(self.integration.controller.config.fast_mode)
+        # Verify adapters registered via the controller
+        adapters = set(self.integration.controller.get_registered_adapters())
+        self.assertIn("wyckoff", adapters)
+        self.assertIn("charting", adapters)
         print("✅ Integration initialization test passed")
 
     def test_wyckoff_adapter_analysis(self):
@@ -76,6 +80,15 @@ class TestPhoenixIntegration(unittest.TestCase):
         self.assertIn("cache_stats", stats)
         self.assertEqual(stats["mode"], "optimized")
         print("✅ Performance stats test passed")
+
+    def test_controller_status(self):
+        """Ensure controller status includes adapter information."""
+        status = self.integration.controller.get_status()
+        self.assertIn("phoenix_session", status)
+        self.assertIn("adapters", status)
+        self.assertIn("wyckoff", status["adapters"])
+        self.assertIn("charting", status["adapters"])
+        print("✅ Controller status test passed")
 
     def test_token_optimization(self):
         """Test token optimization"""
@@ -150,6 +163,7 @@ def run_integration_tests():
     suite.addTest(TestPhoenixIntegration('test_chart_adapter_rendering'))
     suite.addTest(TestPhoenixIntegration('test_phoenix_rise'))
     suite.addTest(TestPhoenixIntegration('test_performance_stats'))
+    suite.addTest(TestPhoenixIntegration('test_controller_status'))
     suite.addTest(TestPhoenixIntegration('test_token_optimization'))
 
     # Add full integration test


### PR DESCRIPTION
## Summary
- implement a working `NCOSPhoenixController` wrapper
- expose adapter registration and status reporting
- extend integration tests for adapter checks and status

## Testing
- `python test_phoenix.py`
- `pytest tests/test_add_structure.py -q` *(fails: ModuleNotFoundError for engines)*

------
https://chatgpt.com/codex/tasks/task_b_68575dba1ca8832eb926a55a50fc2661