### PR TITLE
Add v24.1 orchestrator and engine tests

### DIFF
--- a/_v24_1/tests/__init__.py
+++ b/_v24_1/tests/__init__.py
@@ -1,1 +1,1 @@
-# NCOS Phoenix-Session
+# Tests for v24.1

--- a/_v24_1/tests/test_consolidated_analysis_engine.py
+++ b/_v24_1/tests/test_consolidated_analysis_engine.py
@@ -1,0 +1,34 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+import asyncio
+import pandas as pd
+from unittest.mock import AsyncMock
+from _v24_1.ncos_v24_1_consolidated_analysis_engine import ConsolidatedAnalysisEngine
+
+
+def _mock_data():
+    dates = pd.date_range(end=pd.Timestamp.now(), periods=20, freq='1H')
+    df = pd.DataFrame({
+        'Open': 1.0,
+        'High': 1.0,
+        'Low': 1.0,
+        'Close': 1.0,
+        'Volume': 100
+    }, index=dates)
+    return {'h1': df}
+
+
+def test_analyze_comprehensive_success():
+    engine = ConsolidatedAnalysisEngine()
+    data = _mock_data()
+    result = asyncio.run(engine.analyze_comprehensive('EURUSD', data, 'h1'))
+    assert result['symbol'] == 'EURUSD'
+    assert 'overall_assessment' in result
+
+
+def test_analyze_comprehensive_with_failure():
+    engine = ConsolidatedAnalysisEngine()
+    data = _mock_data()
+    engine.structure_analyzer.analyze = AsyncMock(side_effect=Exception('fail'))
+    result = asyncio.run(engine.analyze_comprehensive('EURUSD', data, 'h1'))
+    assert result['status'] == 'error'
+    assert 'fail' in result['error']

--- a/_v24_1/tests/test_main_orchestrator_v24.py
+++ b/_v24_1/tests/test_main_orchestrator_v24.py
@@ -1,0 +1,32 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+import asyncio
+import pandas as pd
+from unittest.mock import AsyncMock
+from _v24_1.core.orchestrators.ncos_v24_1_main_orchestrator import NCOSMainOrchestrator
+
+
+def test_orchestrator_loads_default_configs(tmp_path):
+    orch = NCOSMainOrchestrator(config_dir=tmp_path)
+    system_cfg = orch.config.get('system_config')
+    assert system_cfg['system']['version'] == '24.1.0'
+
+
+async def run(coro):
+    return await coro
+
+
+def test_analyze_symbol_returns_error_on_fetch_failure(tmp_path):
+    orch = NCOSMainOrchestrator(config_dir=tmp_path)
+    orch.data_pipeline.fetch_and_process = AsyncMock(return_value={'status': 'error', 'message': 'fail'})
+    result = asyncio.run(orch.analyze_symbol('EURUSD'))
+    assert result['status'] == 'error'
+    assert result['message'] == 'fail'
+
+
+def test_analyze_symbol_returns_error_on_analysis_failure(tmp_path):
+    orch = NCOSMainOrchestrator(config_dir=tmp_path)
+    orch.data_pipeline.fetch_and_process = AsyncMock(return_value={'status': 'success', 'data': {'m15': pd.DataFrame()}})
+    orch.analysis_engine.run_full_analysis = AsyncMock(return_value={'status': 'error', 'message': 'analysis failed'})
+    result = asyncio.run(orch.analyze_symbol('EURUSD'))
+    assert result['status'] == 'error'
+    assert result['message'] == 'analysis failed'

--- a/_v24_1/tests/test_unified_strategy_executor.py
+++ b/_v24_1/tests/test_unified_strategy_executor.py
@@ -1,0 +1,45 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+import asyncio
+import pandas as pd
+from _v24_1.ncos_v24_1_unified_strategy_executor import UnifiedStrategyExecutor
+
+
+def _mock_market_df():
+    return pd.DataFrame({
+        'Open': [1.0, 1.0],
+        'High': [1.0, 1.0],
+        'Low': [1.0, 1.0],
+        'Close': [1.0, 1.0],
+        'Volume': [100, 100]
+    })
+
+
+def _base_analysis():
+    return {
+        'analysis': {
+            'structure': {'htf_bias': 'Bullish', 'choch_detected': True, 'bos_detected': True, 'confidence': 0.8},
+            'liquidity': {'sweep_probability': 0.7},
+            'smc': {'fvg_zones': [{'high':1.0, 'low':1.0, 'type':'bullish'}]},
+            'confluence': {'overall_confluence': 0.8, 'rsi_confluence': 0.8}
+        },
+        'confluence_score': 0.8
+    }
+
+
+def test_execute_strategy_inv_success():
+    executor = UnifiedStrategyExecutor({'risk_config': {'account_size': 10000}})
+    market_data = {'m15': _mock_market_df()}
+    analysis_result = _base_analysis()
+    result = asyncio.run(executor.execute_strategy('Inv', market_data, analysis_result, 'EURUSD'))
+    assert result['status'] == 'ready'
+    assert result['strategy'] == 'Inv'
+
+
+def test_execute_strategy_missing_price_data():
+    executor = UnifiedStrategyExecutor({'risk_config': {'account_size': 10000}})
+    executor._get_latest_price_data = lambda data: None
+    market_data = {'m15': _mock_market_df()}
+    analysis_result = _base_analysis()
+    result = asyncio.run(executor.execute_strategy('Inv', market_data, analysis_result, 'EURUSD'))
+    assert result['status'] == 'error'
+


### PR DESCRIPTION
## Summary
- create new tests for NCOS v24.1 orchestrator
- cover UnifiedStrategyExecutor edge cases
- test ConsolidatedAnalysisEngine success and failure paths

## Testing
- `pytest _v24_1/tests/test_main_orchestrator_v24.py _v24_1/tests/test_unified_strategy_executor.py _v24_1/tests/test_consolidated_analysis_engine.py -q`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6857f35b8dd0832e84089e80b92e9a34